### PR TITLE
typo-Update Varsig.cs

### DIFF
--- a/src/libp2p/Libp2p.Core/Enums/Varsig.cs
+++ b/src/libp2p/Libp2p.Core/Enums/Varsig.cs
@@ -4,7 +4,7 @@ public enum Varsig
     // Namespace for all not yet standard signature algorithms
     // draft
     Varsig = 0xd000,
-    // ES256K Siganture Algorithm (secp256k1)
+    // ES256K Signature Algorithm (secp256k1)
     // draft
     Es256k = 0xd0e7,
     // G1 signature for BLS-12381-G2


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
1. **File**: `src/libp2p/Libp2p.Core/Enums/Varsig.cs`
   - Fixed "Siganture" to "Signature" (Line 7).

## Purpose
- Improved code accuracy by fixing the typographical error.
- Enhanced the clarity and professionalism of the codebase.
