### PR TITLE
Fix Typo in `E2eTestSetup.cs`

### DIFF
--- a/src/libp2p/Libp2p.E2eTests/E2eTestSetup.cs
+++ b/src/libp2p/Libp2p.E2eTests/E2eTestSetup.cs
@@ -53,7 +53,7 @@ public class E2eTestSetup : IDisposable
 
         for (; _peerCounter < totalCount; _peerCounter++)
         {
-            // But we create a seprate setup for every peer
+            // But we create a separate setup for every peer
             ServiceProvider sp = ServiceProviders[_peerCounter] =
                 ConfigureServices(
                     new ServiceCollection()


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `E2eTestSetup.cs`**

## Description  
This pull request corrects a typo in the `E2eTestSetup.cs` file to improve the clarity of comments within the code.

### Changes Made:
- **File Modified:** `src/libp2p/Libp2p.E2eTests/E2eTestSetup.cs`
- **Summary of Changes:**  
  - Fixed the typo in the comment from `seprate` to `separate`.

## Checklist  
- [x] Corrected the typo in the source code.
- [x] Verified that the updated code compiles and runs as expected.
- [x] Adhered to the project's contributing guidelines and code of conduct.

## Additional Notes  
This update improves code readability and ensures clear communication for developers working with the E2E test setup.

---

**Allow edits by maintainers:** [x]
