### PR TITLE
Fix Typo in `TestMuxerProtocol.cs`

### DIFF
--- a/src/libp2p/Libp2p.Core.TestsBase/E2e/TestMuxerProtocol.cs
+++ b/src/libp2p/Libp2p.Core.TestsBase/E2e/TestMuxerProtocol.cs
@@ -50,7 +50,7 @@ class TestMuxerProtocol(ChannelBus bus, ILoggerFactory? loggerFactory = null) : 
                 }
                 catch (SessionExistsException)
                 {
-                    logger?.LogDebug($"{context.Peer.Identity.PeerId}: Listener rejected inititation of a redundant session");
+                    logger?.LogDebug($"{context.Peer.Identity.PeerId}: Listener rejected initiation of a redundant session");
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `TestMuxerProtocol.cs`**

## Description  
This pull request fixes a typo in the `TestMuxerProtocol.cs` file, improving the clarity of the logged message.

### Changes Made:
- **File Modified:** `src/libp2p/Libp2p.Core.TestsBase/E2e/TestMuxerProtocol.cs`
- **Summary of Changes:**  
  - Corrected the typo in the log message:  
    `"inititation"` → `"initiation"`

## Checklist  
- [x] Corrected the typo in the log message.
- [x] Verified that this change doesn't impact functionality.

## Additional Notes  
This small correction enhances the clarity of log messages for easier debugging and improves code quality.

---

**Allow edits by maintainers:** [x]
