### PR TITLE
(WIP) Add a generic protocol implementation over ISessionProtocol

### DIFF
--- a/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/Libp2p.Protocols.RequestResponse.Tests.csproj
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/Libp2p.Protocols.RequestResponse.Tests.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="NUnit.Analyzers" />

--- a/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/Libp2p.Protocols.RequestResponse.Tests.csproj
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/Libp2p.Protocols.RequestResponse.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <AssemblyName>Nethermind.$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>Nethermind.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Libp2p.Protocols.RequestResponse\Libp2p.Protocols.RequestResponse.csproj" />
+    <ProjectReference Include="..\Libp2p.Core.TestsBase\Libp2p.Core.TestsBase.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/RequestResponseProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/RequestResponseProtocolTests.cs
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using NUnit.Framework;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Nethermind.Libp2p.Core;
+using System.Text;
+using Nethermind.Libp2p.Core.TestsBase;
+
+namespace Nethermind.Libp2p.Protocols.Tests;
+
+public class TestRequest : IMessage<TestRequest>
+{
+    public string Message { get; set; }
+    public int Value { get; set; }
+
+    public static MessageParser<TestRequest> Parser { get; } =
+        new MessageParser<TestRequest>(() => new TestRequest());
+    public static MessageDescriptor StaticDescriptor { get; } = null;
+    MessageDescriptor IMessage.Descriptor => StaticDescriptor;
+
+    public TestRequest Clone() => new TestRequest { Message = Message, Value = Value };
+    public bool Equals(TestRequest other) => other != null && Message == other.Message && Value == other.Value;
+    public void MergeFrom(TestRequest message) { Message = message.Message; Value = message.Value; }
+    public void MergeFrom(CodedInputStream input) { Message = input.ReadString(); Value = input.ReadInt32(); }
+    public void WriteTo(CodedOutputStream output) { output.WriteString(Message); output.WriteInt32(Value); }
+    public int CalculateSize() => CodedOutputStream.ComputeStringSize(Message) + CodedOutputStream.ComputeInt32Size(Value);
+}
+// Mock interface initialisation for IMessage->TestResponse
+public class TestResponse : IMessage<TestResponse>
+{
+    public string Echo { get; set; }
+    public int ProcessedValue { get; set; }
+
+    public static MessageParser<TestResponse> Parser { get; } =
+        new MessageParser<TestResponse>(() => new TestResponse());
+    public static MessageDescriptor StaticDescriptor { get; } = null;
+    MessageDescriptor IMessage.Descriptor => StaticDescriptor;
+
+    public TestResponse Clone() => new TestResponse { Echo = Echo, ProcessedValue = ProcessedValue };
+    public bool Equals(TestResponse other) =>
+        other != null && Echo == other.Echo && ProcessedValue == other.ProcessedValue;
+    public void MergeFrom(TestResponse message)
+    {
+        Echo = message.Echo;
+        ProcessedValue = message.ProcessedValue;
+    }
+    public void MergeFrom(CodedInputStream input)
+    {
+        Echo = input.ReadString();
+        ProcessedValue = input.ReadInt32();
+    }
+    public void WriteTo(CodedOutputStream output)
+    {
+        output.WriteString(Echo);
+        output.WriteInt32(ProcessedValue);
+    }
+    public int CalculateSize() =>
+        CodedOutputStream.ComputeStringSize(Echo) +
+        CodedOutputStream.ComputeInt32Size(ProcessedValue);
+}
+
+public class GenericRequestResponseProtocolTests
+{
+    [Test]
+    public async Task SetsPropertiesCorrectly()
+    {
+        const string protocolId = "test-protocol";
+
+        var handler = new Func<TestRequest, ISessionContext, Task<TestResponse>>((req, ctx) =>
+            Task.FromResult(new TestResponse
+            {
+                Echo = req.Message,
+                ProcessedValue = req.Value * 2,
+            }));
+
+        var protocol = new GenericRequestResponseProtocol<TestRequest, TestResponse>(
+            protocolId, handler);
+
+        Assert.That(protocol.Id, Is.EqualTo(protocolId));
+
+        // Deserialisation handler check
+        var sampleRequest = new TestRequest { Message = "hi", Value = 5 };
+        var result = await handler(sampleRequest, null);
+
+        Assert.That(result.Echo, Is.EqualTo("hi"));
+        Assert.That(result.ProcessedValue, Is.EqualTo(10));
+    }
+
+    // ToDo : Add more tests.
+}

--- a/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/RequestResponseProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/RequestResponseProtocolTests.cs
@@ -64,7 +64,7 @@ public class TestResponse : IMessage<TestResponse>
         CodedOutputStream.ComputeInt32Size(ProcessedValue);
 }
 
-public class GenericRequestResponseProtocolTests
+public class RequestResponseProtocolTests
 {
     [Test]
     public async Task SetsPropertiesCorrectly()
@@ -78,7 +78,7 @@ public class GenericRequestResponseProtocolTests
                 ProcessedValue = req.Value * 2,
             }));
 
-        var protocol = new GenericRequestResponseProtocol<TestRequest, TestResponse>(
+        var protocol = new RequestResponseProtocol<TestRequest, TestResponse>(
             protocolId, handler);
 
         Assert.That(protocol.Id, Is.EqualTo(protocolId));
@@ -98,7 +98,7 @@ public class GenericRequestResponseProtocolTests
 public class RequestResponseExtensionsTests
 {
     [Test]
-    public void AddGenericRequestResponseProtocol_RegistersProtocolCorrectly()
+    public void AddRequestResponseProtocol_RegistersProtocolCorrectly()
     {
         const string protocolId = "test-extension-protocol";
         var mockBuilder = Substitute.For<IPeerFactoryBuilder>();
@@ -112,34 +112,34 @@ public class RequestResponseExtensionsTests
                 ProcessedValue = req.Value * 2,
             }));
 
-        var result = mockBuilder.AddGenericRequestResponseProtocol<TestRequest, TestResponse>(
+        var result = mockBuilder.AddRequestResponseProtocol<TestRequest, TestResponse>(
             protocolId,
             handler,
             isExposed: true);
 
         Assert.That(result, Is.EqualTo(mockBuilder), "Extension method should return the same builder with the protocol instance added.");
 
-        // Verify that AddAppLayerProtocol was called with a GenericRequestResponseProtocol instance
+        // Verify that AddAppLayerProtocol was called with a RequestResponseProtocol instance
         mockBuilder.Received(1).AddAppLayerProtocol(
-            Arg.Is<GenericRequestResponseProtocol<TestRequest, TestResponse>>(p => p.Id == protocolId),
+            Arg.Is<RequestResponseProtocol<TestRequest, TestResponse>>(p => p.Id == protocolId),
             Arg.Is<bool>(exposed => exposed == true));
     }
 
     [Test]
-    public void AddGenericRequestResponseProtocol_NullProtocolId_ThrowsArgumentNullException()
+    public void AddRequestResponseProtocol_NullProtocolId_ThrowsArgumentNullException()
     {
         var mockBuilder = Substitute.For<IPeerFactoryBuilder>();
         var handler = new Func<TestRequest, ISessionContext, Task<TestResponse>>((req, ctx) =>
             Task.FromResult(new TestResponse()));
 
         Assert.Throws<ArgumentNullException>(() =>
-            mockBuilder.AddGenericRequestResponseProtocol<TestRequest, TestResponse>(
+            mockBuilder.AddRequestResponseProtocol<TestRequest, TestResponse>(
                 null!,
                 handler));
     }
 
     [Test]
-    public void AddGenericRequestResponseProtocol_EmptyProtocolId_CreatesProtocolWithEmptyId()
+    public void AddRequestResponseProtocol_EmptyProtocolId_CreatesProtocolWithEmptyId()
     {
         const string protocolId = "";
         var mockBuilder = Substitute.For<IPeerFactoryBuilder>();
@@ -148,7 +148,7 @@ public class RequestResponseExtensionsTests
         var handler = new Func<TestRequest, ISessionContext, Task<TestResponse>>((req, ctx) =>
             Task.FromResult(new TestResponse()));
 
-        var result = mockBuilder.AddGenericRequestResponseProtocol<TestRequest, TestResponse>(
+        var result = mockBuilder.AddRequestResponseProtocol<TestRequest, TestResponse>(
             protocolId,
             handler);
 
@@ -156,7 +156,7 @@ public class RequestResponseExtensionsTests
 
         // Verify that AddAppLayerProtocol was called with empty protocol ID
         mockBuilder.Received(1).AddAppLayerProtocol(
-            Arg.Is<GenericRequestResponseProtocol<TestRequest, TestResponse>>(p => p.Id == protocolId),
+            Arg.Is<RequestResponseProtocol<TestRequest, TestResponse>>(p => p.Id == protocolId),
             Arg.Is<bool>(exposed => exposed == true));
     }
 }

--- a/src/libp2p/Libp2p.Protocols.RequestResponse/Extension.cs
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse/Extension.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Libp2p.Protocols;
 
 public static class RequestResponseExtensions
 {
-    public static IPeerFactoryBuilder AddGenericRequestResponseProtocol<TRequest, TResponse>(
+    public static IPeerFactoryBuilder AddRequestResponseProtocol<TRequest, TResponse>(
         this IPeerFactoryBuilder builder,
         string protocolId,
         Func<TRequest, ISessionContext, Task<TResponse>> handler,
@@ -20,7 +20,7 @@ public static class RequestResponseExtensions
         where TRequest : class, IMessage<TRequest>, new()
         where TResponse : class, IMessage<TResponse>, new()
     {
-        var protocol = new GenericRequestResponseProtocol<TRequest, TResponse>(
+        var protocol = new RequestResponseProtocol<TRequest, TResponse>(
             protocolId,
             handler,
             loggerFactory);

--- a/src/libp2p/Libp2p.Protocols.RequestResponse/Extension.cs
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse/Extension.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+using Nethermind.Libp2p.Core;
+
+namespace Nethermind.Libp2p.Protocols;
+
+public static class RequestResponseExtensions
+{
+    public static IPeerFactoryBuilder AddGenericRequestResponseProtocol<TRequest, TResponse>(
+        this IPeerFactoryBuilder builder,
+        string protocolId,
+        Func<TRequest, ISessionContext, Task<TResponse>> handler,
+        ILoggerFactory? loggerFactory = null,
+        bool isExposed = true)
+        where TRequest : class, IMessage<TRequest>, new()
+        where TResponse : class, IMessage<TResponse>, new()
+    {
+        var protocol = new GenericRequestResponseProtocol<TRequest, TResponse>(
+            protocolId,
+            handler,
+            loggerFactory);
+
+        return builder.AddAppLayerProtocol(protocol, isExposed);
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.RequestResponse/GenericRequestResponseProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse/GenericRequestResponseProtocol.cs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using System.Buffers;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+using Nethermind.Libp2p.Core;
+using System;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace Nethermind.Libp2p.Protocols;
+
+public class GenericRequestResponseProtocol<TRequest, TResponse> : ISessionProtocol<TRequest, TResponse>
+    where TRequest : class, IMessage<TRequest>, new()
+    where TResponse : class, IMessage<TResponse>, new()
+{
+    private readonly string _protocolId;
+    private readonly Func<TRequest, ISessionContext, Task<TResponse>> _handler;
+    private readonly ILogger<GenericRequestResponseProtocol<TRequest, TResponse>>? _logger;
+
+    public GenericRequestResponseProtocol(
+        string protocolId,
+        Func<TRequest, ISessionContext, Task<TResponse>> handler,
+        ILoggerFactory? loggerFactory = null)
+    {
+        _protocolId = protocolId ?? throw new ArgumentNullException(nameof(protocolId));
+        _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        _logger = loggerFactory?.CreateLogger<GenericRequestResponseProtocol<TRequest, TResponse>>();
+    }
+
+    public string Id => _protocolId;
+
+    public async Task ListenAsync(IChannel channel, ISessionContext context)
+    {
+        try
+        {
+            _logger?.LogDebug("Starting ListenAsync for protocol {ProtocolId} from peer {RemotePeerId}",
+                Id, context.State.RemotePeerId);
+
+            int requestSize = await channel.ReadVarintAsync();
+            _logger?.LogTrace("Received request size: {RequestSize} bytes", requestSize);
+
+            if (requestSize <= 0)
+            {
+                _logger?.LogWarning("Invalid request size: {RequestSize}", requestSize);
+                throw new InvalidDataException($"Invalid request size: {requestSize}");
+            }
+
+            ReadOnlySequence<byte> requestData = await channel.ReadAsync(requestSize, ReadBlockingMode.WaitAll).OrThrow();
+            _logger?.LogTrace("Received request data: {RequestSize} bytes", requestData.Length);
+
+            TRequest request = new TRequest().Descriptor.Parser.ParseFrom(requestData.ToArray()) as TRequest
+                ?? throw new InvalidDataException("Failed to deserialize request");
+
+            _logger?.LogDebug("Successfully deserialized the response");
+
+            TResponse response = await _handler(request, context);
+            _logger?.LogDebug("Handler processed request successfully, response type: {ResponseType}", typeof(TResponse).Name);
+
+            byte[] responseBytes = response.ToByteArray();
+            _logger?.LogTrace("Serialized response: {ResponseSize} bytes", responseBytes.Length);
+
+            await channel.WriteVarintAsync(responseBytes.Length);
+            await channel.WriteAsync(new ReadOnlySequence<byte>(responseBytes));
+
+            _logger?.LogDebug("Response sent successfully for protocol {ProtocolId}", Id);
+
+            await channel.CloseAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error in ListenAsync for protocol {ProtocolId}: {ErrorMessage}", Id, ex.Message);
+            throw;
+        }
+    }
+
+    public async Task<TResponse> DialAsync(IChannel channel, ISessionContext context, TRequest request)
+    {
+        try
+        {
+            _logger?.LogDebug("Starting DialAsync for protocol {ProtocolId} to peer {RemotePeerId}",
+                Id, context.State.RemotePeerId);
+
+            byte[] requestBytes = request.ToByteArray();
+            _logger?.LogTrace("Serialized request: {RequestSize} bytes", requestBytes.Length);
+
+            await channel.WriteVarintAsync(requestBytes.Length);
+            await channel.WriteAsync(new ReadOnlySequence<byte>(requestBytes));
+
+            _logger?.LogDebug("Request sent, waiting for response");
+
+            int responseSize = await channel.ReadVarintAsync();
+            _logger?.LogTrace("Received response size: {ResponseSize} bytes", responseSize);
+
+            if (responseSize <= 0)
+            {
+                _logger?.LogWarning("Invalid response size: {ResponseSize}", responseSize);
+                throw new InvalidDataException($"Invalid response size: {responseSize}");
+            }
+
+            ReadOnlySequence<byte> responseData = await channel.ReadAsync(responseSize, ReadBlockingMode.WaitAll).OrThrow();
+            _logger?.LogTrace("Received response data: {ResponseSize} bytes", responseData.Length);
+
+            TResponse response = new TResponse().Descriptor.Parser.ParseFrom(responseData.ToArray()) as TResponse
+                ?? throw new InvalidDataException("Failed to deserialize response");
+
+            _logger?.LogDebug("Successfully deserialized the response");
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error in DialAsync for protocol {ProtocolId}: {ErrorMessage}", Id, ex.Message);
+            throw;
+        }
+    }
+
+    public override string ToString() => Id;
+}
+

--- a/src/libp2p/Libp2p.Protocols.RequestResponse/Libp2p.Protocols.RequestResponse.csproj
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse/Libp2p.Protocols.RequestResponse.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <AssemblyName>Nethermind.$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>Nethermind.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>libp2p network generic protocol</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Libp2p.Core\Libp2p.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+</Project>

--- a/src/libp2p/Libp2p.Protocols.RequestResponse/README.md
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse/README.md
@@ -4,7 +4,7 @@ The RequestResponse Protocol provides a generic, type-safe implementation of req
 
 ## Overview
 
-The `GenericRequestResponseProtocol<TRequest, TResponse>` class implements the `ISessionProtocol<TRequest, TResponse>` interface, providing:
+The `RequestResponseProtocol<TRequest, TResponse>` class implements the `ISessionProtocol<TRequest, TResponse>` interface, providing:
 
 - **Type Safety**: Strongly typed request and response messages
 - **Protocol Buffers**: Automatic serialization/deserialization using Google.Protobuf
@@ -22,7 +22,7 @@ using Nethermind.Libp2p.Protocols;
 
 // Register the protocol with a handler function
 var peerFactory = new PeerFactoryBuilder()
-    .AddGenericRequestResponseProtocol<ExampleRequest, ExampleResponse>(
+    .AddRequestResponseProtocol<ExampleRequest, ExampleResponse>(
         protocolId: "/example/1.0.0",
         handler: HandleExampleRequest,
         loggerFactory: loggerFactory,
@@ -60,7 +60,7 @@ var request = new ExampleRequest
     Limit = 10
 };
 
-var response = await session.DialAsync<GenericRequestResponseProtocol<ExampleRequest, ExampleResponse>,
+var response = await session.DialAsync<RequestResponseProtocol<ExampleRequest, ExampleResponse>,
                                       ExampleRequest,
                                       ExampleResponse>(request);
 
@@ -80,7 +80,7 @@ The server-side handling is automatic when you register the protocol with a hand
 
 ## Protocol Implementation Details
 
-### GenericRequestResponseProtocol<TRequest, TResponse>
+### RequestResponseProtocol<TRequest, TResponse>
 
 The core protocol class provides:
 
@@ -98,7 +98,7 @@ The core protocol class provides:
 The extension class provides a convenient builder method:
 
 ```csharp
-public static IPeerFactoryBuilder AddGenericRequestResponseProtocol<TRequest, TResponse>(
+public static IPeerFactoryBuilder AddRequestResponseProtocol<TRequest, TResponse>(
     this IPeerFactoryBuilder builder,
     string protocolId,
     Func<TRequest, ISessionContext, Task<TResponse>> handler,

--- a/src/libp2p/Libp2p.Protocols.RequestResponse/README.md
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse/README.md
@@ -1,0 +1,123 @@
+# RequestResponse Protocol
+
+The RequestResponse Protocol provides a generic, type-safe implementation of request-response pattern in libp2p. It enables peers to exchange structured data using Protocol Buffers serialization with automatic message parsing and error handling.
+
+## Overview
+
+The `GenericRequestResponseProtocol<TRequest, TResponse>` class implements the `ISessionProtocol<TRequest, TResponse>` interface, providing:
+
+- **Type Safety**: Strongly typed request and response messages
+- **Protocol Buffers**: Automatic serialization/deserialization using Google.Protobuf
+- **Error Handling**: Comprehensive logging and exception management
+- **Bidirectional Communication**: Support for both client (dial) and server (listen) operations
+
+## Usage
+
+### Register the Protocol
+
+Use the extension method to register your protocol with the peer factory:
+
+```csharp
+using Nethermind.Libp2p.Protocols;
+
+// Register the protocol with a handler function
+var peerFactory = new PeerFactoryBuilder()
+    .AddGenericRequestResponseProtocol<ExampleRequest, ExampleResponse>(
+        protocolId: "/example/1.0.0",
+        handler: HandleExampleRequest,
+        loggerFactory: loggerFactory,
+        isExposed: true)
+    .Build();
+
+// Handler function implementation
+private static async Task<ExampleResponse> HandleExampleRequest(
+    ExampleRequest request,
+    ISessionContext context)
+{
+    // Process the request
+    var results = ProcessQuery(request.Query, request.Limit);
+
+    return new ExampleResponse
+    {
+        Results = { results },
+        Success = true
+    };
+}
+```
+
+### Using the Protocol
+
+#### As a Client (Dialing)
+
+```csharp
+// Connect to a remote peer
+ISession session = await localPeer.DialAsync(remoteAddress);
+
+// Send a request and receive a response
+var request = new ExampleRequest
+{
+    Query = "search term",
+    Limit = 10
+};
+
+var response = await session.DialAsync<GenericRequestResponseProtocol<ExampleRequest, ExampleResponse>,
+                                      ExampleRequest,
+                                      ExampleResponse>(request);
+
+Console.WriteLine($"Success: {response.Success}");
+Console.WriteLine($"Results: {string.Join(", ", response.Results)}");
+```
+
+#### As a Server (Listening)
+
+The server-side handling is automatic when you register the protocol with a handler function. The protocol will:
+
+1. Listen for incoming connections
+2. Deserialize the request message
+3. Call your handler function
+4. Serialize and send the response
+5. Close the connection
+
+## Protocol Implementation Details
+
+### GenericRequestResponseProtocol<TRequest, TResponse>
+
+The core protocol class provides:
+
+- **Constructor Parameters**:
+  - `protocolId`: Unique identifier for the protocol (e.g., "/myapp/1.0.0")
+  - `handler`: Async function to process requests and generate responses
+  - `loggerFactory`: Optional logger factory for debugging
+
+- **Key Methods**:
+  - `ListenAsync()`: Handles incoming requests from remote peers
+  - `DialAsync()`: Sends requests to remote peers and waits for responses
+
+### RequestResponseExtensions
+
+The extension class provides a convenient builder method:
+
+```csharp
+public static IPeerFactoryBuilder AddGenericRequestResponseProtocol<TRequest, TResponse>(
+    this IPeerFactoryBuilder builder,
+    string protocolId,
+    Func<TRequest, ISessionContext, Task<TResponse>> handler,
+    ILoggerFactory? loggerFactory = null,
+    bool isExposed = true)
+```
+
+**Parameters**:
+- `builder`: The peer factory builder to extend
+- `protocolId`: Unique protocol identifier
+- `handler`: Function to handle incoming requests
+- `loggerFactory`: Optional logging factory
+- `isExposed`: Whether the protocol should be advertised to other peers
+
+## Type Constraints
+
+Both `TRequest` and `TResponse` must satisfy:
+
+```csharp
+where TRequest : class, IMessage<TRequest>, new()
+where TResponse : class, IMessage<TResponse>, new()
+```

--- a/src/libp2p/Libp2p.Protocols.RequestResponse/RequestResponseProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse/RequestResponseProtocol.cs
@@ -1,35 +1,33 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
-using System.Buffers;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Nethermind.Libp2p.Core;
-using System;
-using System.Threading.Tasks;
-using System.IO;
 
 namespace Nethermind.Libp2p.Protocols;
 
-public class GenericRequestResponseProtocol<TRequest, TResponse> : ISessionProtocol<TRequest, TResponse>
+public class RequestResponseProtocol<TRequest, TResponse> : ISessionProtocol<TRequest, TResponse>
     where TRequest : class, IMessage<TRequest>, new()
     where TResponse : class, IMessage<TResponse>, new()
 {
     private readonly string _protocolId;
     private readonly Func<TRequest, ISessionContext, Task<TResponse>> _handler;
-    private readonly ILogger<GenericRequestResponseProtocol<TRequest, TResponse>>? _logger;
+    private readonly ILogger<RequestResponseProtocol<TRequest, TResponse>>? _logger;
 
     private readonly MessageParser<TRequest> _requestParser;
     private readonly MessageParser<TResponse> _responseParser;
 
-    public GenericRequestResponseProtocol(
+    public RequestResponseProtocol(
         string protocolId,
         Func<TRequest, ISessionContext, Task<TResponse>> handler,
         ILoggerFactory? loggerFactory = null)
     {
         _protocolId = protocolId ?? throw new ArgumentNullException(nameof(protocolId));
         _handler = handler ?? throw new ArgumentNullException(nameof(handler));
-        _logger = loggerFactory?.CreateLogger<GenericRequestResponseProtocol<TRequest, TResponse>>();
+        _logger = loggerFactory?.CreateLogger<RequestResponseProtocol<TRequest, TResponse>>();
+        _requestParser = new MessageParser<TRequest>(() => new TRequest());
+        _responseParser = new MessageParser<TResponse>(() => new TResponse());
     }
 
     public string Id => _protocolId;

--- a/src/libp2p/Libp2p.slnx
+++ b/src/libp2p/Libp2p.slnx
@@ -17,6 +17,8 @@
     <Project Path="Libp2p.Protocols.Quic.Tests/Libp2p.Protocols.Quic.Tests.csproj" />
     <Project Path="Libp2p.Protocols.Quic/Libp2p.Protocols.Quic.csproj" />
     <Project Path="Libp2p.Protocols.Relay/Libp2p.Protocols.Relay.csproj" />
+    <Project Path="Libp2p.Protocols.RequestResponse/Libp2p.Protocols.RequestResponse.csproj" />
+    <Project Path="Libp2p.Protocols.RequestResponse.Tests/Libp2p.Protocols.RequestResponse.Tests.csproj" />
     <Project Path="Libp2p.Protocols.Tls.Tests/Libp2p.Protocols.Tls.Tests.csproj" />
     <Project Path="Libp2p.Protocols.Tls/Libp2p.Protocols.Tls.csproj" />
     <Project Path="Libp2p.Protocols.Yamux.Tests/Libp2p.Protocols.Yamux.Tests.csproj" />

--- a/src/libp2p/Libp2p/Libp2p.csproj
+++ b/src/libp2p/Libp2p/Libp2p.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\Libp2p.Protocols.Tls\Libp2p.Protocols.Tls.csproj" />
 
     <ProjectReference Include="..\Libp2p.Protocols.PubsubPeerDiscovery\Libp2p.Protocols.PubsubPeerDiscovery.csproj" />
+    <ProjectReference Include="..\Libp2p.Protocols.RequestResponse\Libp2p.Protocols.RequestResponse.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/transport-interop/packages.lock.json
+++ b/src/samples/transport-interop/packages.lock.json
@@ -1297,6 +1297,7 @@
           "Nethermind.Libp2p.Protocols.Pubsub": "[1.0.0, )",
           "Nethermind.Libp2p.Protocols.PubsubPeerDiscovery": "[1.0.0, )",
           "Nethermind.Libp2p.Protocols.Relay": "[1.0.0, )",
+          "Nethermind.Libp2p.Protocols.RequestResponse": "[1.0.0, )",
           "Nethermind.Libp2p.Protocols.Tls": "[1.0.0, )",
           "Nethermind.Libp2p.Protocols.Yamux": "[1.0.0, )"
         }
@@ -1396,6 +1397,14 @@
         "type": "Project",
         "dependencies": {
           "Google.Protobuf": "[3.28.3, )",
+          "Nethermind.Libp2p.Core": "[1.0.0, )"
+        }
+      },
+      "Nethermind.Libp2p.Protocols.RequestResponse": {
+        "type": "Project",
+        "dependencies": {
+          "Google.Protobuf": "[3.28.3, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[9.0.0, )",
           "Nethermind.Libp2p.Core": "[1.0.0, )"
         }
       },


### PR DESCRIPTION
Summary
This PR adds a generic request-response protocol, which is derived from `ISessionProtocol`. This protocol supports customizable request/response types (via Protobuf), a protocol ID, a handler function, and optional logging.

issue: https://github.com/NethermindEth/dotnet-libp2p/issues/123

Key Changes
-  Added `GenericRequestResponseProtocol<TRequest, TResponse>` implementation.
-  Implements both `ListenAsync` and `DialAsync` override methods.
-  A basic test case for the constructor.

To-Do :
- Add an extension method for registering the protocol
- More extensive testing