### PR TITLE
Fix generation using protobuf generator nuget; clean up API

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The target is to provide a performant well-tested implementation of a wide range
 |                    | /meshsub/1.0.0     | ✅             |
 |                    | /meshsub/1.1.0     | 🚧             |
 |                    | /meshsub/1.2.0     | 🚧             |
+| request-response   |                    | ✅             |
 | perf               | /perf/1.0.0        | 🚧             |
 | **Discovery**
 | mDns               | basic w/o DNS-SD   | ✅             |

--- a/src/libp2p/Directory.Packages.props
+++ b/src/libp2p/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <ProtobufVersion>3.28.3</ProtobufVersion>
+    <ProtobufVersion>3.31.1</ProtobufVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />

--- a/src/libp2p/Libp2p.Core.TestsBase/Libp2p.Core.TestsBase.csproj
+++ b/src/libp2p/Libp2p.Core.TestsBase/Libp2p.Core.TestsBase.csproj
@@ -9,13 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Dto\MuxerPacket.proto" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="Dto\MuxerPacket.proto">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </AdditionalFiles>
+    <AdditionalFiles Include="Dto\MuxerPacket.proto" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libp2p/Libp2p.Core/IPeerFactoryBuilder.cs
+++ b/src/libp2p/Libp2p.Core/IPeerFactoryBuilder.cs
@@ -5,7 +5,13 @@ namespace Nethermind.Libp2p.Core;
 
 public interface IPeerFactoryBuilder
 {
-    IPeerFactoryBuilder AddAppLayerProtocol<TProtocol>(TProtocol? instance = default, bool isExposed = true) where TProtocol : IProtocol;
+    /// <summary>
+    /// Adds application layer protocol to the stack. See <see href="https://github.com/NethermindEth/dotnet-libp2p/blob/main/docs/README.md#make-a-protocol-for-your-application">Defining application layer protocol</see>.
+    /// </summary>
+    /// <typeparam name="TProtocol">Protocol type</typeparam>
+    /// <param name="instance">Instance of the protocol can be passed if manual creation is preferred over automatic creation via dependency injection.</param>
+    /// <param name="isExposed">Whether information about protocol support is shared during the handshake.</param>
+    /// <returns>The same builder for chaining calls</returns>
+    IPeerFactoryBuilder AddProtocol<TProtocol>(TProtocol? instance = default, bool isExposed = true) where TProtocol : IProtocol;
     IPeerFactory Build();
-    IEnumerable<IProtocol> AppLayerProtocols { get; }
 }

--- a/src/libp2p/Libp2p.Core/IPeerFactoryBuilder.cs
+++ b/src/libp2p/Libp2p.Core/IPeerFactoryBuilder.cs
@@ -14,4 +14,5 @@ public interface IPeerFactoryBuilder
     /// <returns>The same builder for chaining calls</returns>
     IPeerFactoryBuilder AddProtocol<TProtocol>(TProtocol? instance = default, bool isExposed = true) where TProtocol : IProtocol;
     IPeerFactory Build();
+    IServiceProvider ServiceProvider { get; }
 }

--- a/src/libp2p/Libp2p.Core/Libp2p.Core.csproj
+++ b/src/libp2p/Libp2p.Core/Libp2p.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -14,14 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Dto\SignedEnvelope.proto" />
-  </ItemGroup>
-
-  <ItemGroup>
     <AdditionalFiles Include="Dto\KeyPair.proto" CopyToOutputDirectory="Never" />
-    <AdditionalFiles Include="Dto\PeerRecord.proto">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </AdditionalFiles>
+    <AdditionalFiles Include="Dto\PeerRecord.proto" CopyToOutputDirectory="Never" />
+    <AdditionalFiles Include="Dto\SignedEnvelope.proto" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,10 +40,6 @@
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="Dto\SignedEnvelope.proto" />
   </ItemGroup>
 
 </Project>

--- a/src/libp2p/Libp2p.Core/PeerFactoryBuilderBase.cs
+++ b/src/libp2p/Libp2p.Core/PeerFactoryBuilderBase.cs
@@ -49,12 +49,10 @@ public abstract class PeerFactoryBuilderBase<TBuilder, TPeerFactory> : IPeerFact
 
     private readonly List<ProtocolRef> _appLayerProtocols = [];
 
-    internal readonly IServiceProvider ServiceProvider;
+    public IServiceProvider ServiceProvider { protected set; get; }
 
     protected PeerFactoryBuilderBase(IServiceProvider? serviceProvider = default)
-    {
-        ServiceProvider = serviceProvider ?? new ServiceCollection().BuildServiceProvider();
-    }
+        => ServiceProvider = serviceProvider ?? new ServiceCollection().BuildServiceProvider();
 
     public IPeerFactoryBuilder AddProtocol<TProtocol>(TProtocol? instance = default, bool isExposed = true) where TProtocol : IProtocol
     {

--- a/src/libp2p/Libp2p.Core/PeerFactoryBuilderBase.cs
+++ b/src/libp2p/Libp2p.Core/PeerFactoryBuilderBase.cs
@@ -48,7 +48,6 @@ public abstract class PeerFactoryBuilderBase<TBuilder, TPeerFactory> : IPeerFact
 
 
     private readonly List<ProtocolRef> _appLayerProtocols = [];
-    public IEnumerable<IProtocol> AppLayerProtocols => _appLayerProtocols.Select(x => x.Protocol);
 
     internal readonly IServiceProvider ServiceProvider;
 
@@ -57,7 +56,7 @@ public abstract class PeerFactoryBuilderBase<TBuilder, TPeerFactory> : IPeerFact
         ServiceProvider = serviceProvider ?? new ServiceCollection().BuildServiceProvider();
     }
 
-    public IPeerFactoryBuilder AddAppLayerProtocol<TProtocol>(TProtocol? instance = default, bool isExposed = true) where TProtocol : IProtocol
+    public IPeerFactoryBuilder AddProtocol<TProtocol>(TProtocol? instance = default, bool isExposed = true) where TProtocol : IProtocol
     {
         _appLayerProtocols.Add(new ProtocolRef(CreateProtocolInstance(ServiceProvider!, instance), isExposed));
         return (TBuilder)this;

--- a/src/libp2p/Libp2p.E2eTests/E2eTestSetup.cs
+++ b/src/libp2p/Libp2p.E2eTests/E2eTestSetup.cs
@@ -51,7 +51,7 @@ public class E2eTestSetup : IAsyncDisposable
 
     protected virtual IPeerFactoryBuilder ConfigureLibp2p(ILibp2pPeerFactoryBuilder builder)
     {
-        return builder.AddAppLayerProtocol<IncrementNumberTestProtocol>();
+        return builder.AddProtocol<IncrementNumberTestProtocol>();
     }
 
     protected virtual IServiceCollection ConfigureServices(IServiceCollection col)

--- a/src/libp2p/Libp2p.Generators.Protobuf/Libp2p.Generators.Protobuf.csproj
+++ b/src/libp2p/Libp2p.Generators.Protobuf/Libp2p.Generators.Protobuf.csproj
@@ -11,6 +11,7 @@
     <IsRoslynComponent>true</IsRoslynComponent>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <Version>$(ProtobufVersion)</Version>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -52,6 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 

--- a/src/libp2p/Libp2p.Generators.Protobuf/README.md
+++ b/src/libp2p/Libp2p.Generators.Protobuf/README.md
@@ -4,20 +4,21 @@ The project  automatically generates C# types for protobuf types using protoc(no
 
 ## Usage
 
-1. Add [Google.Protobuf](https://www.nuget.org/packages/Google.Protobuf) package
-1. Add [Libp2p.Generators.Protobuf](https://www.nuget.org/packages/Nethermind.Libp2p.Generators.Protobuf) as analyzer dependency to you project
+1. Add [Google.Protobuf](https://www.nuget.org/packages/Google.Protobuf) package,
+   and [Libp2p.Generators.Protobuf](https://www.nuget.org/packages/Nethermind.Libp2p.Generators.Protobuf) as analyzer dependency to you project
    ```xml
    ...
    <ItemGroup>
      ...
-     <PackageReference Include="Libp2p.Generators.Protobuf" Version="3.25.1" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+     <PackageReference Include="Google.Protobuf" Version="3.31.1" />
+     <PackageReference Include="Libp2p.Generators.Protobuf" Version="3.31.1" />
    </ItemGroup>
    ...
    ```
 1. Make sure that Google.Protobuf version matches Libp2p.Generators.Protobuf project version
 1. Add a .proto file and set "Build Action" to "C# analyzer additional file" for it, "Copy to Output Directory"="Do not copy". It should look like
   `<AdditionalFiles Include="Dto\Rpc.proto" CopyToOutputDirectory="Never" />` in csproj file.
-1. .cs file should be generated next to .proto one.
+1. .cs file should be generated next to the .proto one.
 
 ## Additional notes
 

--- a/src/libp2p/Libp2p.Protocols.PubsubPeerDiscovery.E2eTests/PubsubDiscoveryE2eTestSetup.cs
+++ b/src/libp2p/Libp2p.Protocols.PubsubPeerDiscovery.E2eTests/PubsubDiscoveryE2eTestSetup.cs
@@ -16,7 +16,7 @@ public class PubsubDiscoveryE2eTestSetup : PubsubE2eTestSetup
     protected override IPeerFactoryBuilder ConfigureLibp2p(ILibp2pPeerFactoryBuilder builder)
     {
         return base.ConfigureLibp2p(builder)
-            .AddAppLayerProtocol<IncrementNumberTestProtocol>();
+            .AddProtocol<IncrementNumberTestProtocol>();
     }
 
     protected override IServiceCollection ConfigureServices(IServiceCollection col)

--- a/src/libp2p/Libp2p.Protocols.PubsubPeerDiscovery/Libp2p.Protocols.PubsubPeerDiscovery.csproj
+++ b/src/libp2p/Libp2p.Protocols.PubsubPeerDiscovery/Libp2p.Protocols.PubsubPeerDiscovery.csproj
@@ -14,9 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="Dto\Peer.proto">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </AdditionalFiles>
+    <AdditionalFiles Include="Dto\Peer.proto" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/RequestResponseProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/RequestResponseProtocolTests.cs
@@ -4,11 +4,8 @@
 using NUnit.Framework;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Nethermind.Libp2p.Core;
-using System.Text;
-using Nethermind.Libp2p.Core.TestsBase;
 
 namespace Nethermind.Libp2p.Protocols.Tests;
 
@@ -30,7 +27,7 @@ public class TestRequest : IMessage<TestRequest>
     public int CalculateSize() => CodedOutputStream.ComputeStringSize(Message) + CodedOutputStream.ComputeInt32Size(Value);
 }
 
-// Mock interface initialisation for IMessage->TestResponse
+// Mock interface initialization for IMessage->TestResponse
 public class TestResponse : IMessage<TestResponse>
 {
     public string Echo { get; set; }
@@ -83,7 +80,7 @@ public class RequestResponseProtocolTests
 
         Assert.That(protocol.Id, Is.EqualTo(protocolId));
 
-        // Deserialisation handler check
+        // Deserialization handler check
         var sampleRequest = new TestRequest { Message = "hi", Value = 5 };
         var result = await handler(sampleRequest, null);
 
@@ -103,7 +100,7 @@ public class RequestResponseExtensionsTests
         const string protocolId = "test-extension-protocol";
         var mockBuilder = Substitute.For<IPeerFactoryBuilder>();
 
-        mockBuilder.AddAppLayerProtocol(Arg.Any<IProtocol>(), Arg.Any<bool>()).Returns(mockBuilder);
+        mockBuilder.AddProtocol(Arg.Any<IProtocol>(), Arg.Any<bool>()).Returns(mockBuilder);
 
         var handler = new Func<TestRequest, ISessionContext, Task<TestResponse>>((req, ctx) =>
             Task.FromResult(new TestResponse
@@ -119,8 +116,8 @@ public class RequestResponseExtensionsTests
 
         Assert.That(result, Is.EqualTo(mockBuilder), "Extension method should return the same builder with the protocol instance added.");
 
-        // Verify that AddAppLayerProtocol was called with a RequestResponseProtocol instance
-        mockBuilder.Received(1).AddAppLayerProtocol(
+        // Verify that AddProtocol was called with a RequestResponseProtocol instance
+        mockBuilder.Received(1).AddProtocol(
             Arg.Is<RequestResponseProtocol<TestRequest, TestResponse>>(p => p.Id == protocolId),
             Arg.Is<bool>(exposed => exposed == true));
     }
@@ -143,7 +140,7 @@ public class RequestResponseExtensionsTests
     {
         const string protocolId = "";
         var mockBuilder = Substitute.For<IPeerFactoryBuilder>();
-        mockBuilder.AddAppLayerProtocol(Arg.Any<IProtocol>(), Arg.Any<bool>()).Returns(mockBuilder);
+        mockBuilder.AddProtocol(Arg.Any<IProtocol>(), Arg.Any<bool>()).Returns(mockBuilder);
 
         var handler = new Func<TestRequest, ISessionContext, Task<TestResponse>>((req, ctx) =>
             Task.FromResult(new TestResponse()));
@@ -154,8 +151,8 @@ public class RequestResponseExtensionsTests
 
         Assert.That(result, Is.EqualTo(mockBuilder));
 
-        // Verify that AddAppLayerProtocol was called with empty protocol ID
-        mockBuilder.Received(1).AddAppLayerProtocol(
+        // Verify that AddProtocol was called with empty protocol ID
+        mockBuilder.Received(1).AddProtocol(
             Arg.Is<RequestResponseProtocol<TestRequest, TestResponse>>(p => p.Id == protocolId),
             Arg.Is<bool>(exposed => exposed == true));
     }

--- a/src/libp2p/Libp2p.Protocols.RequestResponse/Extension.cs
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse/Extension.cs
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
-using System;
-using System.Threading.Tasks;
 using Google.Protobuf;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Nethermind.Libp2p.Core;
 
@@ -15,7 +14,6 @@ public static class RequestResponseExtensions
         this IPeerFactoryBuilder builder,
         string protocolId,
         Func<TRequest, ISessionContext, Task<TResponse>> handler,
-        ILoggerFactory? loggerFactory = null,
         bool isExposed = true)
         where TRequest : class, IMessage<TRequest>, new()
         where TResponse : class, IMessage<TResponse>, new()
@@ -23,8 +21,8 @@ public static class RequestResponseExtensions
         var protocol = new RequestResponseProtocol<TRequest, TResponse>(
             protocolId,
             handler,
-            loggerFactory);
+            builder.ServiceProvider.GetService<ILoggerFactory>());
 
-        return builder.AddAppLayerProtocol(protocol, isExposed);
+        return builder.AddProtocol(protocol, isExposed);
     }
 }

--- a/src/libp2p/Libp2p.Protocols.RequestResponse/README.md
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse/README.md
@@ -85,7 +85,7 @@ The server-side handling is automatic when you register the protocol with a hand
 The core protocol class provides:
 
 - **Constructor Parameters**:
-  - `protocolId`: Unique identifier for the protocol (e.g., "/myapp/1.0.0")
+  - `protocolId`: Unique identifier for the protocol (e.g., "/my-app/1.0.0")
   - `handler`: Async function to process requests and generate responses
   - `loggerFactory`: Optional logger factory for debugging
 
@@ -102,7 +102,6 @@ public static IPeerFactoryBuilder AddRequestResponseProtocol<TRequest, TResponse
     this IPeerFactoryBuilder builder,
     string protocolId,
     Func<TRequest, ISessionContext, Task<TResponse>> handler,
-    ILoggerFactory? loggerFactory = null,
     bool isExposed = true)
 ```
 
@@ -110,7 +109,6 @@ public static IPeerFactoryBuilder AddRequestResponseProtocol<TRequest, TResponse
 - `builder`: The peer factory builder to extend
 - `protocolId`: Unique protocol identifier
 - `handler`: Function to handle incoming requests
-- `loggerFactory`: Optional logging factory
 - `isExposed`: Whether the protocol should be advertised to other peers
 
 ## Type Constraints

--- a/src/samples/chat/Program.cs
+++ b/src/samples/chat/Program.cs
@@ -8,7 +8,7 @@ using Nethermind.Libp2p;
 using Nethermind.Libp2p.Core;
 
 ServiceProvider serviceProvider = new ServiceCollection()
-    .AddLibp2p(builder => builder.WithQuic().AddAppLayerProtocol<ChatProtocol>())
+    .AddLibp2p(builder => builder.WithQuic().AddProtocol<ChatProtocol>())
     .AddLogging(builder =>
         builder.SetMinimumLevel(args.Contains("--trace") ? LogLevel.Trace : LogLevel.Trace)
             .AddSimpleConsole(l =>

--- a/src/samples/perf-benchmarks/Program.cs
+++ b/src/samples/perf-benchmarks/Program.cs
@@ -11,7 +11,7 @@ using Nethermind.Libp2p;
 await Task.Delay(1000);
 {
     ServiceProvider serviceProvider = new ServiceCollection()
-        .AddLibp2p(builder => builder.AddAppLayerProtocol<PerfProtocol>())
+        .AddLibp2p(builder => builder.AddProtocol<PerfProtocol>())
         //.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Information).AddSimpleConsole(l=>l.SingleLine = true))
         .BuildServiceProvider();
 
@@ -38,7 +38,7 @@ await Task.Delay(1000);
 
 {
     IPeerFactory peerFactory = NoStackPeerFactoryBuilder.Create
-        .AddAppLayerProtocol<PerfProtocol>()
+        .AddProtocol<PerfProtocol>()
         .Build();
 
     ILocalPeer peer = peerFactory.Create();

--- a/src/samples/transport-interop/packages.lock.json
+++ b/src/samples/transport-interop/packages.lock.json
@@ -1403,7 +1403,7 @@
       "Nethermind.Libp2p.Protocols.RequestResponse": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[3.28.3, )",
+          "Google.Protobuf": "[3.31.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.0, )",
           "Nethermind.Libp2p.Core": "[1.0.0, )"
         }

--- a/src/samples/transport-interop/packages.lock.json
+++ b/src/samples/transport-interop/packages.lock.json
@@ -93,8 +93,8 @@
       },
       "Google.Protobuf": {
         "type": "Transitive",
-        "resolved": "3.28.3",
-        "contentHash": "OewySX3aQCdKfMJsj2DzBMXQJPI+lm0CBzamU9ViFu3CU9tXYrQWqJ1CZ+/UWtkwOjUeIzbXmoOjRc7B8pbMrA=="
+        "resolved": "3.31.1",
+        "contentHash": "gSnJbUmGiOTdWddPhqzrEscHq9Ls6sqRDPB9WptckyjTUyx70JOOAaDLkFff8gManZNN3hllQ4aQInnQyq/Z/A=="
       },
       "IPNetwork2": {
         "type": "Transitive",
@@ -1305,7 +1305,7 @@
         "type": "Project",
         "dependencies": {
           "BouncyCastle.Cryptography": "[2.4.0, )",
-          "Google.Protobuf": "[3.28.3, )",
+          "Google.Protobuf": "[3.31.1, )",
           "Microsoft.Extensions.DependencyInjection": "[9.0.0, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.0, )",
@@ -1316,7 +1316,7 @@
       "Nethermind.Libp2p.Protocols.Identify": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[3.28.3, )",
+          "Google.Protobuf": "[3.31.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.0, )",
           "Nethermind.Libp2p.Core": "[1.0.0, )",
           "Nethermind.Libp2p.Protocols.IpTcp": "[1.0.0, )"
@@ -1347,7 +1347,7 @@
         "type": "Project",
         "dependencies": {
           "BouncyCastle.Cryptography": "[2.4.0, )",
-          "Google.Protobuf": "[3.28.3, )",
+          "Google.Protobuf": "[3.31.1, )",
           "Nethermind.Libp2p.Core": "[1.0.0, )",
           "Noise.NET": "[1.0.0, )",
           "libsodium": "[1.0.20, )"
@@ -1362,7 +1362,7 @@
       "Nethermind.Libp2p.Protocols.Plaintext": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[3.28.3, )",
+          "Google.Protobuf": "[3.31.1, )",
           "Nethermind.Libp2p.Core": "[1.0.0, )"
         }
       },
@@ -1370,7 +1370,7 @@
         "type": "Project",
         "dependencies": {
           "BouncyCastle.Cryptography": "[2.4.0, )",
-          "Google.Protobuf": "[3.28.3, )",
+          "Google.Protobuf": "[3.31.1, )",
           "Nethermind.Libp2p.Core": "[1.0.0, )",
           "Nethermind.Libp2p.Protocols.Identify": "[1.0.0, )"
         }
@@ -1395,7 +1395,7 @@
       "Nethermind.Libp2p.Protocols.Relay": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[3.28.3, )",
+          "Google.Protobuf": "[3.31.1, )",
           "Nethermind.Libp2p.Core": "[1.0.0, )"
         }
       },


### PR DESCRIPTION
- Protobuf generator works now when installed as a nuget package;
- API name shortened, an unused method removed
- protobuf related .csproj  cleanup