### PR TITLE
Add Peer Scoring according to Gossipsub v1.1

### DIFF
--- a/src/libp2p/Libp2p.Protocols.Pubsub/PeerScoreManager.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PeerScoreManager.cs
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Nethermind.Libp2p.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub;
+
+/// <summary>
+/// Manages peer scoring calculations
+/// </summary>
+public class PeerScoreManager
+{
+    private readonly PubsubSettings _settings;
+    private readonly ILogger? _logger;
+
+    public PeerScoreManager(PubsubSettings settings, ILogger? logger = null)
+    {
+        _settings = settings;
+        _logger = logger;
+    }
+
+    public double CalculateScore(PeerState peerState)
+    {
+        double totalScore = 0.0;
+
+        // Calculate topic-based scores
+        foreach (var (topic, topicState) in peerState.TopicStates)
+        {
+            double topicScore = CalculateTopicScore(topicState);
+            totalScore += _settings.TopicWeight * topicScore;
+        }
+
+        // ToDo : Write topic cap config
+        if (_settings.TopicWeight > 0)
+        {
+        }
+
+        // Add global parameters
+        totalScore += _settings.AppSpecificWeight * peerState.GlobalState.AppSpecificScore;
+        totalScore += _settings.IpColocationFactorWeight * peerState.GlobalState.IpColocationFactor;
+        totalScore += _settings.BehaviourPenaltyWeight * peerState.GlobalState.BehaviorPenalty;
+
+        peerState.Score = totalScore;
+        peerState.LastScoreUpdate = DateTime.UtcNow;
+
+        return totalScore;
+    }
+
+    private double CalculateTopicScore(TopicState topicState)
+    {
+        double score = 0.0;
+
+        // P1: Time in Mesh
+        score += _settings.TimeInMeshWeight * CalculateP1(topicState);
+
+        // P2: First Message Deliveries
+        score += _settings.FirstMessageDeliveriesWeight * Math.Min(topicState.FirstMessageDeliveries, _settings.FirstMessageDeliveriesCap);
+
+        // P3: Mesh Message Delivery Rate
+        score += _settings.MeshMessageDeliveriesWeight * CalculateP3(topicState);
+
+        // P3b: Mesh Message Delivery Failures
+        score += _settings.MeshFailurePenaltyWeight * topicState.MeshFailure;
+
+        // P4: Invalid Messages
+        score += _settings.InvalidMessageDeliveriesWeight * topicState.InvalidMessageDeliveries;
+
+        return score;
+    }
+
+    private double CalculateP1(TopicState topicState)
+    {
+        if (topicState.MeshJoinedAt == null)
+            return 0.0;
+
+        var timeInMesh = DateTime.UtcNow - topicState.MeshJoinedAt.Value;
+        double p1 = timeInMesh.TotalSeconds / _settings.TimeInMeshQuantum;
+        return Math.Min(p1, _settings.TimeInMeshCap);
+    }
+
+    private double CalculateP3(TopicState topicState)
+    {
+        if (topicState.MeshMessageDeliveries >= _settings.MeshMessageDeliveriesThreshold)
+        {
+            return 0.0; // No penalty if above threshold
+        }
+
+        // Calculate Penalty
+        double deficit = _settings.MeshMessageDeliveriesThreshold - topicState.MeshMessageDeliveries;
+        return -(deficit * deficit); // Square of the deficit as penalty
+    }
+
+    public bool IsScoreAboveThreshold(PeerState peerState, double threshold)
+    {
+        return peerState.Score >= threshold;
+    }
+
+    /// <summary>
+    /// Apply decay to all scoring parameters
+    /// </summary>
+    public void ApplyDecay(PeerState peerState)
+    {
+        var now = DateTime.UtcNow;
+        var timeSinceLastUpdate = now - peerState.LastScoreUpdate;
+
+        if (timeSinceLastUpdate.TotalSeconds < _settings.DecayInterval)
+            return;
+
+        // Apply decay to each topic
+        foreach (var topicState in peerState.TopicStates.Values)
+        {
+            ApplyTopicDecay(topicState);
+        }
+
+        ApplyGlobalDecay(peerState.GlobalState);
+
+        // Recalculate score after decay
+        CalculateScore(peerState);
+    }
+
+    private void ApplyTopicDecay(TopicState topicState)
+    {
+        topicState.FirstMessageDeliveries *= _settings.FirstMessageDeliveriesDecay;
+
+        topicState.MeshMessageDeliveries *= _settings.MeshMessageDeliveriesDecay;
+
+        topicState.MeshFailure *= _settings.MeshFailurePenaltyDecay;
+
+        topicState.InvalidMessageDeliveries *= _settings.InvalidMessageDeliveriesDecay;
+    }
+
+    private void ApplyGlobalDecay(GlobalScoreState globalState)
+    {
+        // P7: Behavioral Penalty decay
+        globalState.BehaviorPenaltyCounter *= _settings.BehaviourPenaltyDecay;
+        globalState.BehaviorPenalty = globalState.BehaviorPenaltyCounter * globalState.BehaviorPenaltyCounter;
+    }
+
+    public void OnPeerJoinedMesh(PeerState peerState, string topic)
+    {
+        var topicState = peerState.GetOrCreateTopicState(topic);
+        topicState.MeshJoinedAt = DateTime.UtcNow;
+        _logger?.LogDebug($"Peer {peerState.PeerId} joined mesh for topic {topic}");
+    }
+
+    public void OnPeerLeftMesh(PeerState peerState, string topic)
+    {
+        if (peerState.TopicStates.TryGetValue(topic, out var topicState))
+        {
+            topicState.MeshJoinedAt = null;
+            _logger?.LogDebug($"Peer {peerState.PeerId} left mesh for topic {topic}");
+        }
+    }
+
+    public void OnFirstMessageDelivery(PeerState peerState, string topic)
+    {
+        var topicState = peerState.GetOrCreateTopicState(topic);
+        topicState.FirstMessageDeliveries = Math.Min(topicState.FirstMessageDeliveries + 1.0, _settings.FirstMessageDeliveriesCap);
+    }
+
+    public void OnInvalidMessage(PeerState peerState, string topic)
+    {
+        var topicState = peerState.GetOrCreateTopicState(topic);
+        topicState.InvalidMessageDeliveries += 1.0;
+        _logger?.LogWarning($"Invalid message from peer {peerState.PeerId} in topic {topic}");
+    }
+
+    public void ApplyBehavioralPenalty(PeerState peerState, double penalty = 1.0)
+    {
+        peerState.GlobalState.BehaviorPenaltyCounter += penalty;
+        peerState.GlobalState.BehaviorPenalty = peerState.GlobalState.BehaviorPenaltyCounter * peerState.GlobalState.BehaviorPenaltyCounter;
+
+        _logger?.LogWarning($"Applied behavioral penalty {penalty} to peer {peerState.PeerId}");
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PeerState.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PeerState.cs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Nethermind.Libp2p.Core;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub;
+
+/// <summary>
+/// Represents the scoring state for a single peer
+/// </summary>
+public class PeerState
+{
+    public PeerId PeerId { get; }
+    public DateTime ConnectedAt { get; }
+    public DateTime LastScoreUpdate { get; set; }
+
+    public double Score { get; set; } = 0.0;
+
+    /// <summary>
+    /// Per-topic scoring parameters (P1-P4) mapped from a string to a TopicState (Defined below)
+    /// </summary>
+    public Dictionary<string, TopicState> TopicStates { get; } = new();
+
+    public GlobalScoreState GlobalState { get; } = new();
+
+    public PeerState(PeerId peerId)
+    {
+        PeerId = peerId;
+        ConnectedAt = DateTime.UtcNow;
+        LastScoreUpdate = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    ///  TopicState for a given topic
+    /// </summary>
+    public TopicState GetOrCreateTopicState(string topic)
+    {
+        if (!TopicStates.TryGetValue(topic, out var topicState))
+        {
+            topicState = new TopicState(topic);
+            TopicStates[topic] = topicState;
+        }
+        return topicState;
+    }
+}
+
+public class TopicState
+{
+    public string Topic { get; }
+    public DateTime CreatedAt { get; }
+
+    // P1: Time in Mesh
+    public DateTime? MeshJoinedAt { get; set; }
+    public double TimeInMesh { get; set; } = 0.0;
+
+    // P2: First Message Deliveries
+    public double FirstMessageDeliveries { get; set; } = 0.0;
+
+    // P3: Mesh Message Delivery Rate
+    public double MeshMessageDeliveries { get; set; } = 0.0;
+    public double MeshMessageDeliveryDeficit { get; set; } = 0.0;
+
+    // P3b: Mesh Message Delivery Failures
+    public double MeshFailure { get; set; } = 0.0;
+
+    // P4: Invalid Messages
+    public double InvalidMessageDeliveries { get; set; } = 0.0;
+
+    public TopicState(string topic)
+    {
+        Topic = topic;
+        CreatedAt = DateTime.UtcNow;
+    }
+}
+
+public class GlobalScoreState
+{
+    // P5: Application-Specific Score
+    public double AppSpecificScore { get; set; } = 0.0;
+
+    // P6: IP Colocation Factor
+    public double IpColocationFactor { get; set; } = 0.0;
+
+    // P7: Behavioral Penalty
+    public double BehaviorPenaltyCounter { get; set; } = 0.0;
+    public double BehaviorPenalty { get; set; } = 0.0;
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -10,32 +10,134 @@ public class PubsubSettings
 {
     public static PubsubSettings Default { get; } = new();
 
+    // Connection and Reconnection Settings
     public int ReconnectionAttempts { get; set; } = 10;
     public int ReconnectionPeriod { get; set; } = 15_000;
-
-    public int Degree { get; set; } = 6; // The desired outbound degree of the network 	6
-    public int LowestDegree { get; set; } = 4; // Lower bound for outbound degree 	4
-    public int HighestDegree { get; set; } = 12; // Upper bound for outbound degree 	12
-    public int LazyDegree { get; set; } = 6; // (Optional) the outbound degree for gossip emission D
-
     public int MaxConnections { get; set; }
 
-    public int HeartbeatInterval { get; set; } = 1_000; // Time between heartbeats 	1 second
-    public int FanoutTtl { get; set; } = 60 * 1000; // Time-to-live for each topic's fanout state 	60 seconds
-    public int mcache_len { get; set; } = 5; // Number of history windows in message cache 	5
-    public int mcache_gossip { get; set; } = 3; // Number of history windows to use when emitting gossip 	3
-    public int MessageCacheTtl { get; set; } = 2 * 60 * 1000; // Expiry time for cache of seen message ids 	2 minutes
-    public SignaturePolicy DefaultSignaturePolicy { get; set; } = SignaturePolicy.StrictSign;
+    // Network Topology Settings
+    /// <summary>
+    /// The desired outbound degree of the network
+    /// </summary>
+    public int Degree { get; set; } = 6;
+
+    /// <summary>
+    /// Lower bound for outbound degree
+    /// </summary>
+    public int LowestDegree { get; set; } = 4;
+
+    /// <summary>
+    /// Upper bound for outbound degree
+    /// </summary>
+    public int HighestDegree { get; set; } = 12;
+
+    /// <summary>
+    /// (Optional) the outbound degree for gossip emission, equal to <see cref="Degree"/> by default
+    /// </summary>
+    public int LazyDegree { get => lazyDegree ?? Degree; set => lazyDegree = value; }
+    private int? lazyDegree = null;
+
+    // Timing Settings
+    /// <summary>
+    /// Time between heartbeats (in milliseconds)
+    /// </summary>
+    public int HeartbeatInterval { get; set; } = 1_000;
+
+    /// <summary>
+    /// Time-to-live for each topic's fanout state (in milliseconds)
+    /// </summary>
+    public int FanoutTtl { get; set; } = 60 * 1000;
+
+    /// <summary>
+    /// Expiry time for cache of seen message ids (in milliseconds)
+    /// </summary>
+    public int SeenTtl { get; set; } = 2 * 60 * 1000;
+
+    public int PruneBackoff { get; set; } = 1 * 60 * 1000;
+    public int UnsubscribeBackoff { get; set; } = 10 * 1000;
+
+    // Message Cache Settings
+    /// <summary>
+    /// Number of history windows in message cache
+    /// </summary>
+    public int MessageCacheLen { get; set; } = 5;
+
+    /// <summary>
+    /// Number of history windows to use when emitting gossip
+    /// </summary>
+    public int MessageCacheGossip { get; set; } = 3;
+
+    /// <summary>
+    /// Message cache TTL (in milliseconds)
+    /// </summary>
+    public int MessageCacheTtl { get; set; } = 2 * 60 * 1000;
+
+    // Publishing and Gossip Settings
+    public bool FloodPublish { get; set; } = true;
+    public double GossipFactor { get; set; } = 0.25;
+    public int DScore { get; set; } = 5;
+    public int DOut { get; set; } = 2;
     public int MaxIdontwantMessages { get; set; } = 50;
 
+    // Message Handling
+    /// <summary>
+    /// Message id generator, uses From and SeqNo concatenation by default
+    /// </summary>
     public Func<Message, MessageId> GetMessageId { get; set; } = ConcatFromAndSeqno;
+
+    public SignaturePolicy DefaultSignaturePolicy { get; set; } = SignaturePolicy.StrictSign;
+
+    // Peer Scoring Thresholds
+    public double GossipThreshold { get; set; } = 0;
+    public double PublishThreshold { get; set; } = 0;
+    public double GraylistThreshold { get; set; } = 0;
+    public double AcceptPXThreshold { get; set; } = 0;
+    public double OpportunisticGraftThreshold { get; set; } = 0;
+
+    // Score Decay Settings
+    public double DecayInterval { get; set; } = 1;
+    public double DecayToZero { get; set; } = 1;
+    public double RetainScore { get; set; } = 1;
+
+    // Global Peer Scoring Parameters
+    public double AppSpecificWeight { get; set; } = 1;
+    public double IpColocationFactorWeight { get; set; } = 1;
+    public double IpColocationFactorThreshold { get; set; } = 1;
+    public double BehaviourPenaltyWeight { get; set; } = 1;
+    public double BehaviourPenaltyDecay { get; set; } = 1;
+    public double TopicWeight { get; set; } = 1;
+
+    // P1: Time in Mesh
+    public double TimeInMeshWeight { get; set; } = 1;
+    public double TimeInMeshQuantum { get; set; } = 1;
+    public double TimeInMeshCap { get; set; } = 1;
+
+    // P2: First Message Deliveries
+    public double FirstMessageDeliveriesWeight { get; set; } = 1;
+    public double FirstMessageDeliveriesDecay { get; set; } = 1;
+    public double FirstMessageDeliveriesCap { get; set; } = 1;
+
+    // P3: Mesh Message Deliveries
+    public double MeshMessageDeliveriesWeight { get; set; } = 1;
+    public double MeshMessageDeliveriesDecay { get; set; } = 1;
+    public double MeshMessageDeliveriesThreshold { get; set; } = 1;
+    public double MeshMessageDeliveriesCap { get; set; } = 1;
+    public double MeshMessageDeliveriesActivation { get; set; } = 1;
+    public double MeshMessageDeliveryWindow { get; set; } = 1;
+
+    // P3b: Mesh Failure Penalty
+    public double MeshFailurePenaltyWeight { get; set; } = 1;
+    public double MeshFailurePenaltyDecay { get; set; } = 1;
+
+    // P4: Invalid Message Deliveries
+    public double InvalidMessageDeliveriesWeight { get; set; } = 1;
+    public double InvalidMessageDeliveriesDecay { get; set; } = 1;
 
     public enum SignaturePolicy
     {
         StrictSign,
         StrictNoSign,
     }
-
 
     public static MessageId ConcatFromAndSeqno(Message message) => new([.. message.From, .. message.Seqno]);
 }


### PR DESCRIPTION
(Work in Progress)

**Summary**
This PR introduces peer scoring configurations based on the Gossipsub v1.1 specification. 

**Issue** : #139 

**Key Changes**
- Added PeerState class to track topic scores for each peer, and it is initialized and managed in PubsubRouter.cs
- Introduced PeerScoreManager class, which is responsible for calculating and updating peer scores according to Gossipsub v1.1 rules
- Updated PubsubSettings.cs to include peer scoring parameters (P1–P7) as defined in the Gossipsub spec

**To-Do**
- Integrate PeerScoreManager into the heartbeat function for periodic score updates
- Run a pubsub connection test to validate scoring behavior
- Add comprehensive unit tests to cover various scoring scenarios