### PR TITLE
Fix async/await anti-patterns in ChannelStream

### DIFF
--- a/src/libp2p/Libp2p.Core/Stream.cs
+++ b/src/libp2p/Libp2p.Core/Stream.cs
@@ -38,7 +38,7 @@ public class ChannelStream : Stream
     {
         if (buffer is { Length: 0 } && _canRead) return 0;
 
-        ReadResult result = _chan.ReadAsync(buffer.Length, ReadBlockingMode.WaitAny).Result;
+        ReadResult result = _chan.ReadAsync(buffer.Length, ReadBlockingMode.WaitAny).GetAwaiter().GetResult();
         if (result.Result != IOResult.Ok)
         {
             _canRead = false;
@@ -51,7 +51,7 @@ public class ChannelStream : Stream
 
     public override void Write(byte[] buffer, int offset, int count)
     {
-        if (_chan.WriteAsync(new ReadOnlySequence<byte>(buffer.AsMemory(offset, count))).Result != IOResult.Ok)
+        if (_chan.WriteAsync(new ReadOnlySequence<byte>(buffer.AsMemory(offset, count))).GetAwaiter().GetResult() != IOResult.Ok)
         {
             _canWrite = false;
         }


### PR DESCRIPTION
- Replaced `.Result` calls with `.GetAwaiter().GetResult()` in synchronous `Read()` and `Write()` methods to avoid potential deadlocks and improve exception handling.
- Better exception propagation (no `AggregateException` wrapping)
- Reduces deadlock risk in synchronization contexts
