### PR TITLE
Bug : https://github.com/NethermindEth/dotnet-libp2p/issues/168

### DIFF
--- a/src/libp2p/Libp2p.Core.Tests/VarintTests.cs
+++ b/src/libp2p/Libp2p.Core.Tests/VarintTests.cs
@@ -1,0 +1,56 @@
+namespace Nethermind.Libp2p.Core.Tests;
+public class VarintTests
+{
+   [Test]
+   public async Task Test_VarInt_Assumption_And_Roundtrip_Encoding()
+   {
+      Assert.That(5,  Is.EqualTo(VarInt.GetSizeInBytes(System.Int32.MinValue)));
+      Assert.That(1,  Is.EqualTo(VarInt.GetSizeInBytes(System.UInt64.MinValue)));
+      Assert.That(5,  Is.EqualTo(VarInt.GetSizeInBytes(System.Int32.MaxValue)));
+      Assert.That(10, Is.EqualTo(VarInt.GetSizeInBytes(System.UInt64.MaxValue)));
+      Assert.That(1, Is.EqualTo(VarInt.GetSizeInBytes(1UL)));
+      Assert.That(1, Is.EqualTo(VarInt.GetSizeInBytes(0UL)));
+      Assert.That(1, Is.EqualTo(VarInt.GetSizeInBytes(1)));
+      Assert.That(1, Is.EqualTo(VarInt.GetSizeInBytes(0)));
+      Span<byte> memoryA = stackalloc byte[10];
+      int offset = 0;
+      VarInt.Encode(System.UInt64.MaxValue, memoryA, ref offset);
+      offset = 0;
+      Assert.That(System.UInt64.MaxValue, Is.EqualTo(VarInt.Decode(memoryA, ref offset)));
+      offset = 0;
+      memoryA.Clear();
+
+      VarInt.Encode(System.UInt64.MinValue, memoryA, ref offset);
+      offset = 0;
+      Assert.That(System.UInt64.MinValue, Is.EqualTo(VarInt.Decode(memoryA, ref offset)));
+      offset = 0;
+      memoryA.Clear();
+
+      System.UInt64 roundtrip_ulong_target = (ulong) System.Random.Shared.NextInt64();
+      VarInt.Encode(roundtrip_ulong_target, memoryA, ref offset);
+      offset = 0;
+      Assert.That(roundtrip_ulong_target, Is.EqualTo(VarInt.Decode(memoryA, ref offset)));
+      offset = 0;
+      memoryA.Clear();
+
+      Span<byte> memoryB = stackalloc byte[5];
+      VarInt.Encode(System.Int32.MaxValue, memoryB, ref offset);
+      offset = 0;
+      Assert.That(System.Int32.MaxValue, Is.EqualTo(VarInt.Decode(memoryB, ref offset)));
+      offset = 0;
+      memoryB.Clear();
+
+      VarInt.Encode(System.Int32.MinValue, memoryB, ref offset);
+      offset = 0;
+      Assert.That(System.Int32.MinValue, Is.EqualTo((int) VarInt.Decode(memoryB, ref offset)));
+      offset = 0;
+      memoryB.Clear();
+
+      System.Int32 roundtrip_int_target = System.Random.Shared.Next();
+      VarInt.Encode(roundtrip_int_target, memoryB, ref offset);
+      offset = 0;
+      Assert.That(roundtrip_int_target, Is.EqualTo((int) VarInt.Decode(memoryB, ref offset)));
+      offset = 0;
+      memoryB.Clear();
+   }
+}

--- a/src/libp2p/Libp2p.Core/VarInt.cs
+++ b/src/libp2p/Libp2p.Core/VarInt.cs
@@ -2,32 +2,18 @@
 // SPDX-License-Identifier: MIT
 
 namespace Nethermind.Libp2p.Core;
-
+using System.Runtime.CompilerServices;
 public static class VarInt
 {
-    public static void Encode(int number, Span<byte> buf, ref int offset)
-    {
-        for (int i = 0; i < 9; i++)
-        {
-            byte newByte = (byte)(number & 127);
-            number >>= 7;
-
-            if (number != 0)
-            {
-                buf[offset + i] = (byte)(newByte | 128);
-            }
-            else
-            {
-                buf[offset + i] = newByte;
-                offset += i + 1;
-                return;
-            }
-        }
-    }
-
+    //(ulong)((uint) number) casts number to uint first then ulong because apparently I had to
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Encode(int number, Span<byte> buf, ref int offset) => Encode((ulong)((uint) number), buf, ref offset);
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Encode(ulong number, Span<byte> buf, ref int offset)
     {
-        for (int i = 0; i < 9; i++)
+        int byte_number = GetSizeInBytes(number);
+        for (int i = 0; i < byte_number; i++)
         {
             byte newByte = (byte)(number & 127);
             number >>= 7;
@@ -45,62 +31,55 @@ public static class VarInt
         }
     }
 
-    public static int GetSizeInBytes(int number)
-    {
-        for (int i = 1; i <= 9; i++)
-        {
-            number >>= 7;
+    //(ulong)((uint) number) casts number to uint first then ulong because apparently I had to
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetSizeInBytes(int number) => GetSizeInBytes((ulong)((uint) number));
 
-            if (number == 0)
-            {
-                return i;
-            }
-        }
-
-        throw new ArgumentException(nameof(number));
-    }
-
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetSizeInBytes(ulong number)
     {
-        for (int i = 1; i <= 9; i++)
-        {
-            number >>= 7;
-
-            if (number == 0)
-            {
-                return i;
-            }
-        }
-
-        throw new ArgumentException(nameof(number));
+        int bit_number = System.Numerics.BitOperations.Log2(number) + 1;
+        return (bit_number + 6) / 7;
     }
-
-    public static ulong Decode(Span<byte> line, ref int offset)
+    /// <summary>
+    /// Decode either the encoded 32bit integer or 64bit unsigned integer to unsigned integer 64bit
+    /// </summary>
+    /// <param name="line"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong Decode(Span<byte> source, ref int offset)
     {
-        ulong res = 0;
-        for (int i = 0; i < 9; i++)
+        ulong result = 0;
+        int shift = 0;
+        int bytesRead = 0;
+        //search for a range no larger than the span and no larger than 10 bytes passed offset (encoding support almost System.UInt64 which encodes to 10 bytes maximum)
+        while (bytesRead < source.Length)
         {
-            if ((line[offset + i] & 128) == 0)
+            byte @byte = source[offset + bytesRead++];
+            // Use the AND operator (& 0x7F) to get the 7 bits of data
+            // Use the OR operator (|=) to add them to the result
+            result |= ((ulong) (@byte & 0x7F)) << shift;
+
+            // Check the 8th bit: If it is 0, return the result
+            if ((@byte & 0x80) == 0)
             {
-                for (int j = offset + i; j >= offset; j--)
-                {
-                    res <<= 7;
-                    res |= (ulong)line[j] & 127;
-                }
-
-                offset += i + 1;
-                return res;
+                offset = offset + (shift / 7);
+                return result;
             }
+            shift += 7;
+            // Safety check: a 64-bit int can't be more than 10 bytes (10 * 7 = 70)
+            if (shift >= 70) throw new FormatException("Invalid 7-bit encoding");
         }
-
-        return 0;
+        throw new EndOfStreamException("Exhausted span before end of integer.");
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static async Task<ulong> DecodeUlong(IReader buf)
     {
         ulong res = 0;
         byte mul = 0;
-        for (int i = 0; i < 9; i++)
+        for (int i = 0; i < 10; i++)
         {
             byte @byte = (await buf.ReadAsync(1).OrThrow()).FirstSpan[0];
             res += ((ulong)@byte & 127) << mul;
@@ -110,15 +89,15 @@ public static class VarInt
                 return res;
             }
         }
-
-        return 0;
+        throw new FormatException("Invalid 7-bit encoding");
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static async Task<int> Decode(IReader buf, CancellationToken token = default)
     {
         int res = 0;
         byte mul = 0;
-        for (int i = 0; i < 9; i++)
+        for (int i = 0; i < 5; i++)
         {
             byte @byte = (await buf.ReadAsync(1, token: token).OrThrow()).FirstSpan[0];
             res += (@byte & 127) << mul;
@@ -128,7 +107,6 @@ public static class VarInt
                 return res;
             }
         }
-
-        return 0;
+        throw new FormatException("Invalid 7-bit encoding");
     }
 }


### PR DESCRIPTION
Bug

Adjusted assumption of VarInt encoded length

Reimplemented GetSizeInBytes so its same functionality but faster (in reasoning) and exceptionless

Added aggressive inlining attributes for optimization

Decoding now throwing exceptions if it's reading pass the expected boundry

Added tests for ensuring it works