### PR TITLE
feat: add DCUtR hole punch protocol

### DIFF
--- a/src/libp2p/Libp2p.Protocols.NatTraversal.Tests/HolePunchMessageCodecTests.cs
+++ b/src/libp2p/Libp2p.Protocols.NatTraversal.Tests/HolePunchMessageCodecTests.cs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Multiformats.Address;
+using Nethermind.Libp2p.Protocols.NatTraversal;
+
+namespace Libp2p.Protocols.NatTraversal.Tests;
+
+public class HolePunchMessageCodecTests
+{
+    [Test]
+    public void RoundTripConnectMessage()
+    {
+        Multiaddress[] addresses =
+        [
+            Multiaddress.Decode("/ip4/127.0.0.1/tcp/4001"),
+            Multiaddress.Decode("/dns4/example.com/tcp/443/wss")
+        ];
+
+        byte[] encoded = HolePunchMessageCodec.Encode(HolePunchMessage.Connect(addresses));
+        HolePunchMessage decoded = HolePunchMessageCodec.Decode(encoded);
+
+        Assert.That(decoded.Type, Is.EqualTo(HolePunchMessageType.Connect));
+        Assert.That(decoded.ObservedAddresses.Select(a => a.ToString()), Is.EqualTo(addresses.Select(a => a.ToString())));
+    }
+
+    [Test]
+    public void RoundTripSyncMessage()
+    {
+        byte[] encoded = HolePunchMessageCodec.Encode(HolePunchMessage.Sync());
+        HolePunchMessage decoded = HolePunchMessageCodec.Decode(encoded);
+
+        Assert.That(decoded.Type, Is.EqualTo(HolePunchMessageType.Sync));
+        Assert.That(decoded.ObservedAddresses, Is.Empty);
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.NatTraversal.Tests/Libp2p.Protocols.NatTraversal.Tests.csproj
+++ b/src/libp2p/Libp2p.Protocols.NatTraversal.Tests/Libp2p.Protocols.NatTraversal.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableNUnitRunner>true</EnableNUnitRunner>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Nethermind.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <AssemblyName>Nethermind.$(MSBuildProjectName)</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Libp2p.Protocols.NatTraversal\Libp2p.Protocols.NatTraversal.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/libp2p/Libp2p.Protocols.NatTraversal/Extensions/ServiceCollectionExtensions.cs
+++ b/src/libp2p/Libp2p.Protocols.NatTraversal/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Nethermind.Libp2p.Core;
+
+namespace Nethermind.Libp2p.Protocols.NatTraversal.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IPeerFactoryBuilder AddNatHolePunch(this IPeerFactoryBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.AddProtocol<NatHolePunchProtocol>();
+        return builder;
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.NatTraversal/HolePunchMessage.cs
+++ b/src/libp2p/Libp2p.Protocols.NatTraversal/HolePunchMessage.cs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Multiformats.Address;
+
+namespace Nethermind.Libp2p.Protocols.NatTraversal;
+
+public enum HolePunchMessageType
+{
+    Connect = 100,
+    Sync = 300
+}
+
+public sealed record HolePunchMessage(HolePunchMessageType Type, IReadOnlyList<Multiaddress> ObservedAddresses)
+{
+    public static HolePunchMessage Connect(IEnumerable<Multiaddress> observedAddresses)
+        => new(HolePunchMessageType.Connect, [.. observedAddresses]);
+
+    public static HolePunchMessage Sync()
+        => new(HolePunchMessageType.Sync, []);
+}
+
+public static class HolePunchMessageCodec
+{
+    private const int TypeField = 1;
+    private const int ObservedAddressField = 2;
+
+    public static byte[] Encode(HolePunchMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        using var stream = new MemoryStream();
+        WriteTag(stream, TypeField, ProtobufWireType.Varint);
+        WriteVarint(stream, (ulong)message.Type);
+
+        foreach (Multiaddress address in message.ObservedAddresses)
+        {
+            byte[] addressBytes = address.ToBytes();
+            WriteTag(stream, ObservedAddressField, ProtobufWireType.LengthDelimited);
+            WriteVarint(stream, (ulong)addressBytes.Length);
+            stream.Write(addressBytes);
+        }
+
+        return stream.ToArray();
+    }
+
+    public static HolePunchMessage Decode(ReadOnlySpan<byte> bytes)
+    {
+        HolePunchMessageType? type = null;
+        List<Multiaddress> observedAddresses = [];
+        int offset = 0;
+
+        while (offset < bytes.Length)
+        {
+            ulong tag = ReadVarint(bytes, ref offset);
+            int fieldNumber = (int)(tag >> 3);
+            ProtobufWireType wireType = (ProtobufWireType)(tag & 0x07);
+
+            switch (fieldNumber, wireType)
+            {
+                case (TypeField, ProtobufWireType.Varint):
+                    type = (HolePunchMessageType)ReadVarint(bytes, ref offset);
+                    break;
+                case (ObservedAddressField, ProtobufWireType.LengthDelimited):
+                    ulong length = ReadVarint(bytes, ref offset);
+                    if (length > int.MaxValue || offset + (int)length > bytes.Length)
+                        throw new FormatException("Hole punch observed address is truncated.");
+
+                    observedAddresses.Add(Multiaddress.Decode(bytes.Slice(offset, (int)length).ToArray()));
+                    offset += (int)length;
+                    break;
+                default:
+                    SkipField(bytes, wireType, ref offset);
+                    break;
+            }
+        }
+
+        return type is null
+            ? throw new FormatException("Hole punch message is missing a type.")
+            : new HolePunchMessage(type.Value, observedAddresses);
+    }
+
+    private static void WriteTag(Stream stream, int fieldNumber, ProtobufWireType wireType)
+        => WriteVarint(stream, (ulong)((fieldNumber << 3) | (int)wireType));
+
+    private static void WriteVarint(Stream stream, ulong value)
+    {
+        while (value >= 0x80)
+        {
+            stream.WriteByte((byte)(value | 0x80));
+            value >>= 7;
+        }
+
+        stream.WriteByte((byte)value);
+    }
+
+    private static ulong ReadVarint(ReadOnlySpan<byte> bytes, ref int offset)
+    {
+        ulong value = 0;
+        int shift = 0;
+
+        while (offset < bytes.Length && shift < 64)
+        {
+            byte current = bytes[offset++];
+            value |= (ulong)(current & 0x7f) << shift;
+            if ((current & 0x80) == 0)
+                return value;
+
+            shift += 7;
+        }
+
+        throw new FormatException("Invalid protobuf varint.");
+    }
+
+    private static void SkipField(ReadOnlySpan<byte> bytes, ProtobufWireType wireType, ref int offset)
+    {
+        switch (wireType)
+        {
+            case ProtobufWireType.Varint:
+                _ = ReadVarint(bytes, ref offset);
+                break;
+            case ProtobufWireType.Fixed64:
+                offset += 8;
+                break;
+            case ProtobufWireType.LengthDelimited:
+                ulong length = ReadVarint(bytes, ref offset);
+                if (length > int.MaxValue)
+                    throw new FormatException("Length-delimited protobuf field is too large.");
+                offset += (int)length;
+                break;
+            case ProtobufWireType.Fixed32:
+                offset += 4;
+                break;
+            default:
+                throw new FormatException($"Unsupported protobuf wire type {wireType}.");
+        }
+
+        if (offset > bytes.Length)
+            throw new FormatException("Protobuf field is truncated.");
+    }
+
+    private enum ProtobufWireType
+    {
+        Varint = 0,
+        Fixed64 = 1,
+        LengthDelimited = 2,
+        Fixed32 = 5
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.NatTraversal/Libp2p.Protocols.NatTraversal.csproj
+++ b/src/libp2p/Libp2p.Protocols.NatTraversal/Libp2p.Protocols.NatTraversal.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <AssemblyName>Nethermind.$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>Nethermind.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>libp2p network nat traversal hole punch dcutr</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Libp2p.Core\Libp2p.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+</Project>

--- a/src/libp2p/Libp2p.Protocols.NatTraversal/NatHolePunchProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.NatTraversal/NatHolePunchProtocol.cs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using System.Buffers;
+using Microsoft.Extensions.Logging;
+using Multiformats.Address;
+using Nethermind.Libp2p.Core;
+
+namespace Nethermind.Libp2p.Protocols.NatTraversal;
+
+public sealed class NatHolePunchProtocol : ISessionProtocol<HolePunchRequest, HolePunchResult>
+{
+    private static readonly HolePunchRequest EmptyRequest = new([]);
+    private readonly ILogger<NatHolePunchProtocol>? _logger;
+
+    public NatHolePunchProtocol(ILoggerFactory? loggerFactory = null)
+    {
+        _logger = loggerFactory?.CreateLogger<NatHolePunchProtocol>();
+    }
+
+    public string Id => "/libp2p/dcutr";
+
+    public event EventHandler<HolePunchRequestedEventArgs>? HolePunchRequested;
+
+    public async Task ListenAsync(IChannel downChannel, ISessionContext context)
+    {
+        HolePunchMessage connect = await ReadMessageAsync(downChannel).ConfigureAwait(false);
+        if (connect.Type != HolePunchMessageType.Connect)
+            throw new InvalidOperationException($"Expected CONNECT, received {connect.Type}.");
+
+        PeerId? remotePeerId = context.State.RemotePeerId;
+        HolePunchRequested?.Invoke(this, new HolePunchRequestedEventArgs(remotePeerId, connect.ObservedAddresses));
+
+        Multiaddress[] observedAddresses = [.. context.Peer.ListenAddresses];
+        _logger?.LogDebug("Received DCUtR CONNECT from {PeerId} with {AddressCount} observed address(es).",
+            remotePeerId, connect.ObservedAddresses.Count);
+
+        await WriteMessageAsync(downChannel, HolePunchMessage.Connect(observedAddresses)).ConfigureAwait(false);
+
+        HolePunchMessage sync = await ReadMessageAsync(downChannel).ConfigureAwait(false);
+        if (sync.Type != HolePunchMessageType.Sync)
+            throw new InvalidOperationException($"Expected SYNC, received {sync.Type}.");
+
+        await downChannel.CloseAsync().ConfigureAwait(false);
+    }
+
+    public async Task<HolePunchResult> DialAsync(IChannel downChannel, ISessionContext context, HolePunchRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        await WriteMessageAsync(downChannel, HolePunchMessage.Connect(request.ObservedAddresses)).ConfigureAwait(false);
+        HolePunchMessage response = await ReadMessageAsync(downChannel).ConfigureAwait(false);
+
+        if (response.Type != HolePunchMessageType.Connect)
+            throw new InvalidOperationException($"Expected CONNECT, received {response.Type}.");
+
+        await WriteMessageAsync(downChannel, HolePunchMessage.Sync()).ConfigureAwait(false);
+        await downChannel.CloseAsync().ConfigureAwait(false);
+
+        _logger?.LogDebug("Completed DCUtR coordination with {AddressCount} remote observed address(es).",
+            response.ObservedAddresses.Count);
+
+        return new HolePunchResult(response.ObservedAddresses);
+    }
+
+    public Task<HolePunchResult> DialAsync(IChannel downChannel, ISessionContext context)
+        => DialAsync(downChannel, context, EmptyRequest);
+
+    private static async Task<HolePunchMessage> ReadMessageAsync(IChannel channel)
+    {
+        int length = await channel.ReadVarintAsync().ConfigureAwait(false);
+        ReadOnlySequence<byte> payload = await channel.ReadAsync(length).OrThrow().ConfigureAwait(false);
+        return HolePunchMessageCodec.Decode(payload.ToArray());
+    }
+
+    private static async Task WriteMessageAsync(IChannel channel, HolePunchMessage message)
+    {
+        await channel.WriteSizeAndDataAsync(HolePunchMessageCodec.Encode(message)).ConfigureAwait(false);
+    }
+}
+
+public sealed record HolePunchRequest(IReadOnlyCollection<Multiaddress> ObservedAddresses);
+
+public sealed record HolePunchResult(IReadOnlyList<Multiaddress> RemoteObservedAddresses);
+
+public sealed class HolePunchRequestedEventArgs : EventArgs
+{
+    public HolePunchRequestedEventArgs(PeerId? remotePeerId, IReadOnlyList<Multiaddress> observedAddresses)
+    {
+        RemotePeerId = remotePeerId;
+        ObservedAddresses = observedAddresses;
+    }
+
+    public PeerId? RemotePeerId { get; }
+    public IReadOnlyList<Multiaddress> ObservedAddresses { get; }
+}

--- a/src/libp2p/Libp2p.Protocols.NatTraversal/README.md
+++ b/src/libp2p/Libp2p.Protocols.NatTraversal/README.md
@@ -1,0 +1,26 @@
+# Libp2p.Protocols.NatTraversal
+
+NAT traversal coordination for libp2p peers.
+
+## Features
+
+- DCUtR (`/libp2p/dcutr`) hole-punch coordination
+- CONNECT/SYNC message exchange
+- Observed-address exchange using libp2p-compatible protobuf wire encoding
+
+## Usage
+
+```csharp
+using Nethermind.Libp2p.Protocols.NatTraversal;
+using Nethermind.Libp2p.Protocols.NatTraversal.Extensions;
+
+builder.AddNatHolePunch();
+
+HolePunchResult result = await session.DialAsync<NatHolePunchProtocol, HolePunchRequest, HolePunchResult>(
+    new HolePunchRequest(observedAddresses),
+    token);
+```
+
+## License
+
+MIT

--- a/src/libp2p/Libp2p.slnx
+++ b/src/libp2p/Libp2p.slnx
@@ -9,6 +9,8 @@
     <Project Path="Libp2p.Protocols.MDns/Libp2p.Protocols.MDns.csproj" />
     <Project Path="Libp2p.Protocols.Multistream.Tests/Libp2p.Protocols.Multistream.Tests.csproj" />
     <Project Path="Libp2p.Protocols.Multistream/Libp2p.Protocols.Multistream.csproj" />
+    <Project Path="Libp2p.Protocols.NatTraversal.Tests/Libp2p.Protocols.NatTraversal.Tests.csproj" />
+    <Project Path="Libp2p.Protocols.NatTraversal/Libp2p.Protocols.NatTraversal.csproj" />
     <Project Path="Libp2p.Protocols.Noise.Tests/Libp2p.Protocols.Noise.Tests.csproj" />
     <Project Path="Libp2p.Protocols.Noise/Libp2p.Protocols.Noise.csproj" />
     <Project Path="Libp2p.Protocols.Ping/Libp2p.Protocols.Ping.csproj" />


### PR DESCRIPTION
## Summary

This PR introduces the initial implementation of DCUtR (Direct Connection Upgrade through Relay) support by adding a dedicated NAT traversal project and implementing the core `/libp2p/dcutr` coordination flow used for relay-assisted hole punching.

### Changes

* Added a standalone `Libp2p.Protocols.NatTraversal` project for NAT traversal and hole-punch coordination protocols
* Implemented the initial `/libp2p/dcutr` protocol flow:

  * CONNECT message handling
  * SYNC message exchange
  * observed-address propagation between peers
* Added a lightweight protobuf-based wire codec for encoding and decoding DCUtR protocol messages
* Added NUnit round-trip tests covering:

  * protobuf serialization/deserialization
  * message integrity across encode/decode cycles
  * protocol payload compatibility checks
* Registered both protocol and test projects in `Libp2p.slnx`

### Implementation Notes

The current implementation focuses on the coordination layer required before direct socket hole punching occurs. The protocol exchange allows peers connected through a relay to:

* exchange observed external addresses
* synchronize connection attempts
* prepare for direct transport upgrades

This PR is scoped specifically to the DCUtR protocol layer and codec infrastructure. It does not yet include:

* transport-level hole punching
* STUN/TURN integration
* automatic relay fallback
* WebRTC transport integration
* connection upgrade orchestration

### Repository Scope

This branch is based on upstream `main` and is intentionally isolated from the existing WebRTC/NAT traversal feature branch to keep the protocol-layer implementation reviewable independently.

