### PR TITLE
Fix pubsub TTL cache eviction

### DIFF
--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
+
+[TestFixture]
+public class TtlCacheTests
+{
+    [Test]
+    public void RemoveExpired_RemovesEntriesRegardlessOfKeyOrder()
+    {
+        using TtlCache<MessageId> cache = new(50);
+        MessageId expiredHigh = new([0xFF]);
+        MessageId liveLow = new([0x01]);
+
+        cache.Add(expiredHigh);
+        Thread.Sleep(80);
+        cache.Add(liveLow);
+
+        cache.RemoveExpired(DateTimeOffset.UtcNow);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Contains(expiredHigh), Is.False);
+            Assert.That(cache.Contains(liveLow), Is.True);
+        });
+    }
+
+    [Test]
+    public void ExpiredEntries_AreNotReturnedBeforeTheSweeperRuns()
+    {
+        using TtlCache<MessageId, string> cache = new(25);
+        MessageId id = new([0x01]);
+        cache.Add(id, "value");
+
+        Thread.Sleep(60);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Contains(id), Is.False);
+            Assert.That(cache.TryGet(id, out _), Is.False);
+            Assert.That(cache.ToList(), Is.Empty);
+        });
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
@@ -9,12 +9,12 @@ public class TtlCacheTests
     [Test]
     public void RemoveExpired_RemovesEntriesRegardlessOfKeyOrder()
     {
-        using TtlCache<MessageId> cache = new(50);
+        using TtlCache<MessageId> cache = new(500);
         MessageId expiredHigh = new([0xFF]);
         MessageId liveLow = new([0x01]);
 
         cache.Add(expiredHigh);
-        Thread.Sleep(80);
+        Thread.Sleep(750);
         cache.Add(liveLow);
 
         cache.RemoveExpired(DateTimeOffset.UtcNow);
@@ -29,11 +29,11 @@ public class TtlCacheTests
     [Test]
     public void ExpiredEntries_AreNotReturned()
     {
-        using TtlCache<MessageId, string> cache = new(25);
+        using TtlCache<MessageId, string> cache = new(500);
         MessageId id = new([0x01]);
         cache.Add(id, "value");
 
-        Thread.Sleep(60);
+        Thread.Sleep(750);
 
         Assert.Multiple(() =>
         {
@@ -46,11 +46,11 @@ public class TtlCacheTests
     [Test]
     public void Add_ReplacesAnExpiredEntry()
     {
-        using TtlCache<MessageId, string> cache = new(25);
+        using TtlCache<MessageId, string> cache = new(500);
         MessageId id = new([0x01]);
         cache.Add(id, "expired");
 
-        Thread.Sleep(60);
+        Thread.Sleep(750);
         cache.Add(id, "replacement");
 
         Assert.That(cache.Get(id), Is.EqualTo("replacement"));

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
@@ -55,4 +55,24 @@ public class TtlCacheTests
 
         Assert.That(cache.Get(id), Is.EqualTo("replacement"));
     }
+
+    [Test]
+    public void Add_EvictsTheOldestLiveEntryAtCapacity()
+    {
+        using TtlCache<MessageId, string> cache = new(ttl: 1_000, maxEntries: 2);
+        MessageId first = new([0x01]);
+        MessageId second = new([0x02]);
+        MessageId third = new([0x03]);
+
+        cache.Add(first, "first");
+        cache.Add(second, "second");
+        cache.Add(third, "third");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Contains(first), Is.False);
+            Assert.That(cache.Get(second), Is.EqualTo("second"));
+            Assert.That(cache.Get(third), Is.EqualTo("third"));
+        });
+    }
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
@@ -14,13 +14,15 @@ public class TtlCacheTests
         MessageId liveLow = new([0x01]);
 
         cache.Add(expiredHigh);
-        Thread.Sleep(750);
+        DateTimeOffset expiredAfter = DateTimeOffset.UtcNow.AddMilliseconds(500);
+        Assert.That(() => DateTimeOffset.UtcNow >= expiredAfter, Is.True.After(2_000, 25));
         cache.Add(liveLow);
 
         cache.RemoveExpired(DateTimeOffset.UtcNow);
 
         Assert.Multiple(() =>
         {
+            Assert.That(cache.Count, Is.EqualTo(1));
             Assert.That(cache.Contains(expiredHigh), Is.False);
             Assert.That(cache.Contains(liveLow), Is.True);
         });
@@ -33,7 +35,7 @@ public class TtlCacheTests
         MessageId id = new([0x01]);
         cache.Add(id, "value");
 
-        Thread.Sleep(750);
+        Assert.That(() => cache.Contains(id), Is.False.After(2_000, 25));
 
         Assert.Multiple(() =>
         {
@@ -50,7 +52,7 @@ public class TtlCacheTests
         MessageId id = new([0x01]);
         cache.Add(id, "expired");
 
-        Thread.Sleep(750);
+        Assert.That(() => cache.Contains(id), Is.False.After(2_000, 25));
         cache.Add(id, "replacement");
 
         Assert.That(cache.Get(id), Is.EqualTo("replacement"));

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
@@ -23,6 +23,7 @@ public class TtlCacheTests
         Assert.Multiple(() =>
         {
             Assert.That(cache.Count, Is.EqualTo(1));
+            Assert.That(cache.EntryOrderCount, Is.EqualTo(1));
             Assert.That(cache.Contains(expiredHigh), Is.False);
             Assert.That(cache.Contains(liveLow), Is.True);
         });

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
@@ -27,7 +27,7 @@ public class TtlCacheTests
     }
 
     [Test]
-    public void ExpiredEntries_AreNotReturnedBeforeTheSweeperRuns()
+    public void ExpiredEntries_AreNotReturned()
     {
         using TtlCache<MessageId, string> cache = new(25);
         MessageId id = new([0x01]);

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TtlCacheTests.cs
@@ -42,4 +42,17 @@ public class TtlCacheTests
             Assert.That(cache.ToList(), Is.Empty);
         });
     }
+
+    [Test]
+    public void Add_ReplacesAnExpiredEntry()
+    {
+        using TtlCache<MessageId, string> cache = new(25);
+        MessageId id = new([0x01]);
+        cache.Add(id, "expired");
+
+        Thread.Sleep(60);
+        cache.Add(id, "replacement");
+
+        Assert.That(cache.Get(id), Is.EqualTo("replacement"));
+    }
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
@@ -6,18 +6,23 @@ namespace Nethermind.Libp2p.Protocols.Pubsub;
 internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
 {
     private readonly int ttl;
+    private readonly int maxEntries;
     private readonly object sync = new();
     private readonly Dictionary<TKey, CachedItem> items = [];
+    private readonly Queue<(TKey Key, long Sequence)> insertionOrder = [];
     private readonly CancellationTokenSource sweeperCancellation = new();
     private readonly Task sweeperTask;
     private int disposed;
+    private long sequence;
 
-    private readonly record struct CachedItem(TItem Item, DateTimeOffset ValidTill);
+    private readonly record struct CachedItem(TItem Item, DateTimeOffset ValidTill, long Sequence);
 
-    public TtlCache(int ttl)
+    public TtlCache(int ttl, int maxEntries = int.MaxValue)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(ttl);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxEntries);
         this.ttl = ttl;
+        this.maxEntries = maxEntries;
         sweeperTask = Task.Run(async () =>
         {
             try
@@ -42,10 +47,15 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
     {
         lock (sync)
         {
-            if (items.TryGetValue(key, out CachedItem cachedItem) && cachedItem.ValidTill > DateTimeOffset.UtcNow)
+            if (items.TryGetValue(key, out CachedItem cachedItem))
             {
-                item = cachedItem.Item;
-                return true;
+                if (cachedItem.ValidTill > DateTimeOffset.UtcNow)
+                {
+                    item = cachedItem.Item;
+                    return true;
+                }
+
+                items.Remove(key);
             }
         }
 
@@ -57,27 +67,7 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
     {
         lock (sync)
         {
-            if (items.Count == 0)
-            {
-                return;
-            }
-
-            List<TKey>? expired = null;
-            foreach ((TKey key, CachedItem item) in items)
-            {
-                if (item.ValidTill <= now)
-                {
-                    (expired ??= []).Add(key);
-                }
-            }
-
-            if (expired is not null)
-            {
-                foreach (TKey key in expired)
-                {
-                    items.Remove(key);
-                }
-            }
+            RemoveExpiredLocked(now);
         }
     }
 
@@ -85,13 +75,60 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
     {
         lock (sync)
         {
-            if (items.TryGetValue(key, out CachedItem cachedItem) && cachedItem.ValidTill <= DateTimeOffset.UtcNow)
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            if (items.TryGetValue(key, out CachedItem cachedItem))
             {
+                if (cachedItem.ValidTill > now)
+                {
+                    return;
+                }
+
                 items.Remove(key);
             }
 
-            items.TryAdd(key, new CachedItem(item, DateTimeOffset.UtcNow.AddMilliseconds(ttl)));
+            while (items.Count >= maxEntries)
+            {
+                EvictOldest();
+            }
+
+            long itemSequence = ++sequence;
+            items.Add(key, new CachedItem(item, now.AddMilliseconds(ttl), itemSequence));
+            insertionOrder.Enqueue((key, itemSequence));
         }
+    }
+
+    private void RemoveExpiredLocked(DateTimeOffset now)
+    {
+        List<TKey>? expired = null;
+        foreach ((TKey key, CachedItem item) in items)
+        {
+            if (item.ValidTill <= now)
+            {
+                (expired ??= []).Add(key);
+            }
+        }
+
+        if (expired is not null)
+        {
+            foreach (TKey key in expired)
+            {
+                items.Remove(key);
+            }
+        }
+    }
+
+    private void EvictOldest()
+    {
+        while (insertionOrder.TryDequeue(out (TKey Key, long Sequence) oldest))
+        {
+            if (items.TryGetValue(oldest.Key, out CachedItem item) && item.Sequence == oldest.Sequence)
+            {
+                items.Remove(oldest.Key);
+                return;
+            }
+        }
+
+        throw new InvalidOperationException("TTL cache insertion order was unexpectedly empty.");
     }
 
     public void Dispose()
@@ -108,6 +145,7 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
         lock (sync)
         {
             items.Clear();
+            insertionOrder.Clear();
         }
     }
 
@@ -124,7 +162,7 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
     }
 }
 
-internal class TtlCache<TKey>(int ttl) : TtlCache<TKey, bool>(ttl) where TKey : notnull
+internal class TtlCache<TKey>(int ttl, int maxEntries = int.MaxValue) : TtlCache<TKey, bool>(ttl, maxEntries) where TKey : notnull
 {
     public void Add(TKey key) => Add(key, true);
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
@@ -6,68 +6,118 @@ namespace Nethermind.Libp2p.Protocols.Pubsub;
 internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
 {
     private readonly int ttl;
+    private readonly object sync = new();
+    private readonly Dictionary<TKey, CachedItem> items = [];
+    private readonly CancellationTokenSource sweeperCancellation = new();
+    private int disposed;
 
-    private struct CachedItem
-    {
-        public TItem Item { get; set; }
-        public DateTimeOffset ValidTill { get; set; }
-    }
-
-    private readonly SortedDictionary<TKey, CachedItem> items = [];
-    private bool isDisposed;
+    private readonly record struct CachedItem(TItem Item, DateTimeOffset ValidTill);
 
     public TtlCache(int ttl)
     {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(ttl);
         this.ttl = ttl;
-        Task.Run(async () =>
+        _ = Task.Run(async () =>
         {
-            while (!isDisposed)
+            try
             {
-                await Task.Delay(5_000);
-                DateTimeOffset now = DateTimeOffset.UtcNow;
-                lock (items)
+                while (true)
                 {
-                    TKey[] keys = items.TakeWhile(i => i.Value.ValidTill < now).Select(i => i.Key).ToArray();
-                    foreach (TKey keyToRemove in keys)
-                    {
-                        items.Remove(keyToRemove);
-                    }
+                    await Task.Delay(Math.Min(5_000, ttl), sweeperCancellation.Token);
+                    RemoveExpired(DateTimeOffset.UtcNow);
                 }
+            }
+            catch (OperationCanceledException) when (sweeperCancellation.IsCancellationRequested)
+            {
             }
         });
     }
 
-    public bool Contains(TKey key) => items.ContainsKey(key);
+    public bool Contains(TKey key) => TryGet(key, out _);
 
-    public TItem Get(TKey key) => items.GetValueOrDefault(key).Item;
+    public TItem Get(TKey key) => TryGet(key, out TItem item) ? item : default!;
+
+    public bool TryGet(TKey key, out TItem item)
+    {
+        lock (sync)
+        {
+            if (items.TryGetValue(key, out CachedItem cachedItem) && cachedItem.ValidTill > DateTimeOffset.UtcNow)
+            {
+                item = cachedItem.Item;
+                return true;
+            }
+        }
+
+        item = default!;
+        return false;
+    }
+
+    internal void RemoveExpired(DateTimeOffset now)
+    {
+        lock (sync)
+        {
+            if (items.Count == 0)
+            {
+                return;
+            }
+
+            List<TKey>? expired = null;
+            foreach ((TKey key, CachedItem item) in items)
+            {
+                if (item.ValidTill <= now)
+                {
+                    (expired ??= []).Add(key);
+                }
+            }
+
+            if (expired is not null)
+            {
+                foreach (TKey key in expired)
+                {
+                    items.Remove(key);
+                }
+            }
+        }
+    }
 
     public void Add(TKey key, TItem item)
     {
-        lock (items)
+        lock (sync)
         {
-            items.TryAdd(key, new CachedItem
-            {
-                Item = item,
-                ValidTill = DateTimeOffset.UtcNow.AddMilliseconds(ttl),
-            });
+            items.TryAdd(key, new CachedItem(item, DateTimeOffset.UtcNow.AddMilliseconds(ttl)));
         }
     }
 
     public void Dispose()
     {
-        isDisposed = true;
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+        {
+            return;
+        }
+
+        sweeperCancellation.Cancel();
+        sweeperCancellation.Dispose();
+
+        lock (sync)
+        {
+            items.Clear();
+        }
     }
 
     internal IList<TItem> ToList()
     {
-        lock (items)
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        lock (sync)
         {
-            return items.Values.Select(i => i.Item).ToList();
+            return items.Values
+                .Where(item => item.ValidTill > now)
+                .Select(item => item.Item)
+                .ToList();
         }
     }
 }
 
 internal class TtlCache<TKey>(int ttl) : TtlCache<TKey, bool>(ttl) where TKey : notnull
 {
-    public void Add(TKey key) => Add(key, false);
+    public void Add(TKey key) => Add(key, true);
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
@@ -43,6 +43,17 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
 
     public TItem Get(TKey key) => TryGet(key, out TItem item) ? item : default!;
 
+    internal int Count
+    {
+        get
+        {
+            lock (sync)
+            {
+                return items.Count;
+            }
+        }
+    }
+
     public bool TryGet(TKey key, out TItem item)
     {
         lock (sync)

--- a/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
@@ -24,7 +24,7 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
             {
                 while (true)
                 {
-                    await Task.Delay(Math.Min(5_000, ttl), sweeperCancellation.Token);
+                    await Task.Delay(5_000, sweeperCancellation.Token);
                     RemoveExpired(DateTimeOffset.UtcNow);
                 }
             }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
@@ -9,6 +9,7 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
     private readonly object sync = new();
     private readonly Dictionary<TKey, CachedItem> items = [];
     private readonly CancellationTokenSource sweeperCancellation = new();
+    private readonly Task sweeperTask;
     private int disposed;
 
     private readonly record struct CachedItem(TItem Item, DateTimeOffset ValidTill);
@@ -17,7 +18,7 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(ttl);
         this.ttl = ttl;
-        _ = Task.Run(async () =>
+        sweeperTask = Task.Run(async () =>
         {
             try
             {
@@ -84,6 +85,11 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
     {
         lock (sync)
         {
+            if (items.TryGetValue(key, out CachedItem cachedItem) && cachedItem.ValidTill <= DateTimeOffset.UtcNow)
+            {
+                items.Remove(key);
+            }
+
             items.TryAdd(key, new CachedItem(item, DateTimeOffset.UtcNow.AddMilliseconds(ttl)));
         }
     }
@@ -96,6 +102,7 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
         }
 
         sweeperCancellation.Cancel();
+        sweeperTask.GetAwaiter().GetResult();
         sweeperCancellation.Dispose();
 
         lock (sync)

--- a/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/TtlCache.cs
@@ -9,13 +9,11 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
     private readonly int maxEntries;
     private readonly object sync = new();
     private readonly Dictionary<TKey, CachedItem> items = [];
-    private readonly Queue<(TKey Key, long Sequence)> insertionOrder = [];
+    private readonly LinkedList<TKey> insertionOrder = [];
     private readonly CancellationTokenSource sweeperCancellation = new();
     private readonly Task sweeperTask;
     private int disposed;
-    private long sequence;
-
-    private readonly record struct CachedItem(TItem Item, DateTimeOffset ValidTill, long Sequence);
+    private readonly record struct CachedItem(TItem Item, DateTimeOffset ValidTill, LinkedListNode<TKey> Node);
 
     public TtlCache(int ttl, int maxEntries = int.MaxValue)
     {
@@ -54,6 +52,17 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
         }
     }
 
+    internal int EntryOrderCount
+    {
+        get
+        {
+            lock (sync)
+            {
+                return insertionOrder.Count;
+            }
+        }
+    }
+
     public bool TryGet(TKey key, out TItem item)
     {
         lock (sync)
@@ -66,7 +75,7 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
                     return true;
                 }
 
-                items.Remove(key);
+                Remove(key, cachedItem);
             }
         }
 
@@ -94,7 +103,7 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
                     return;
                 }
 
-                items.Remove(key);
+                Remove(key, cachedItem);
             }
 
             while (items.Count >= maxEntries)
@@ -102,9 +111,8 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
                 EvictOldest();
             }
 
-            long itemSequence = ++sequence;
-            items.Add(key, new CachedItem(item, now.AddMilliseconds(ttl), itemSequence));
-            insertionOrder.Enqueue((key, itemSequence));
+            LinkedListNode<TKey> node = insertionOrder.AddLast(key);
+            items.Add(key, new CachedItem(item, now.AddMilliseconds(ttl), node));
         }
     }
 
@@ -123,23 +131,30 @@ internal class TtlCache<TKey, TItem> : IDisposable where TKey : notnull
         {
             foreach (TKey key in expired)
             {
-                items.Remove(key);
+                Remove(key, items[key]);
             }
         }
     }
 
     private void EvictOldest()
     {
-        while (insertionOrder.TryDequeue(out (TKey Key, long Sequence) oldest))
+        LinkedListNode<TKey>? oldest = insertionOrder.First;
+        if (oldest is null)
         {
-            if (items.TryGetValue(oldest.Key, out CachedItem item) && item.Sequence == oldest.Sequence)
-            {
-                items.Remove(oldest.Key);
-                return;
-            }
+            throw new InvalidOperationException("TTL cache insertion order was unexpectedly empty.");
         }
 
-        throw new InvalidOperationException("TTL cache insertion order was unexpectedly empty.");
+        insertionOrder.RemoveFirst();
+        if (!items.Remove(oldest.Value))
+        {
+            throw new InvalidOperationException("TTL cache insertion order was out of sync with its entries.");
+        }
+    }
+
+    private void Remove(TKey key, CachedItem item)
+    {
+        items.Remove(key);
+        insertionOrder.Remove(item.Node);
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary

- remove expired TTL-cache entries by expiration time instead of key ordering
- make cache access and disposal safe while a sweeper is active
- add regression coverage for out-of-order keys and lazy expiration

## Pipeline repair

This branch also includes the shared SIPSorcery security dependency update required for CI restore. It aligns the WebRTC certificate integration and is tracked independently in #208.

## Validation

- Focused cache regression coverage passes.