### PR TITLE
Bound incoming pubsub RPC frames

### DIFF
--- a/src/libp2p/Libp2p.Core/IReader.cs
+++ b/src/libp2p/Libp2p.Core/IReader.cs
@@ -42,7 +42,12 @@ public interface IReader
         return VarInt.Decode(this, token);
     }
 
-    Task<ulong> ReadVarintUlongAsync(CancellationToken token = default)
+    Task<ulong> ReadVarintUlongAsync()
+    {
+        return VarInt.DecodeUlong(this);
+    }
+
+    Task<ulong> ReadVarintUlongAsync(CancellationToken token)
     {
         return VarInt.DecodeUlong(this, token);
     }

--- a/src/libp2p/Libp2p.Core/IReader.cs
+++ b/src/libp2p/Libp2p.Core/IReader.cs
@@ -42,15 +42,27 @@ public interface IReader
         return VarInt.Decode(this, token);
     }
 
-    Task<ulong> ReadVarintUlongAsync()
+    Task<ulong> ReadVarintUlongAsync(CancellationToken token = default)
     {
-        return VarInt.DecodeUlong(this);
+        return VarInt.DecodeUlong(this, token);
     }
 
-    async ValueTask<T> ReadPrefixedProtobufAsync<T>(MessageParser<T> parser, CancellationToken token = default) where T : IMessage<T>
+    ValueTask<T> ReadPrefixedProtobufAsync<T>(MessageParser<T> parser, CancellationToken token = default) where T : IMessage<T>
     {
-        int messageLength = await ReadVarintAsync(token);
-        ReadOnlySequence<byte> serializedMessage = await ReadAsync(messageLength, token: token).OrThrow();
+        return ReadPrefixedProtobufAsync(parser, int.MaxValue, token);
+    }
+
+    async ValueTask<T> ReadPrefixedProtobufAsync<T>(MessageParser<T> parser, int maxMessageLength, CancellationToken token = default) where T : IMessage<T>
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(maxMessageLength);
+
+        ulong messageLength = await ReadVarintUlongAsync(token);
+        if (messageLength > (ulong)maxMessageLength)
+        {
+            throw new InvalidDataException($"Incoming protobuf message size {messageLength} exceeds the limit of {maxMessageLength}");
+        }
+
+        ReadOnlySequence<byte> serializedMessage = await ReadAsync((int)messageLength, token: token).OrThrow();
 
         return parser.ParseFrom(serializedMessage);
     }

--- a/src/libp2p/Libp2p.Core/VarInt.cs
+++ b/src/libp2p/Libp2p.Core/VarInt.cs
@@ -77,16 +77,23 @@ public static class VarInt
         throw new EndOfStreamException("Exhausted span before end of integer.");
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static async Task<ulong> DecodeUlong(IReader buf)
+    public static Task<ulong> DecodeUlong(IReader buf)
+    {
+        return DecodeUlong(buf, default);
+    }
+
+    public static async Task<ulong> DecodeUlong(IReader buf, CancellationToken token = default)
     {
         ulong res = 0;
-        byte mul = 0;
         for (int i = 0; i < 10; i++)
         {
-            byte @byte = (await buf.ReadAsync(1).OrThrow()).FirstSpan[0];
-            res += ((ulong)@byte & 127) << mul;
-            mul += 7;
+            byte @byte = (await buf.ReadAsync(1, token: token).OrThrow()).FirstSpan[0];
+            if (i == 9 && (@byte & 0x7f) > 1)
+            {
+                throw new FormatException("Invalid 7-bit encoding");
+            }
+
+            res |= ((ulong)@byte & 127) << (i * 7);
             if ((@byte & 128) == 0)
             {
                 return res;

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubFrameLimitTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubFrameLimitTests.cs
@@ -22,9 +22,13 @@ public class PubsubFrameLimitTests
     }
 
     [Test]
-    public void MaxRpcBytes_RejectsNegativeValues()
+    public void MaxRpcBytes_RejectsNonPositiveValues()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new PubsubSettings { MaxRpcBytes = -1 });
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PubsubSettings { MaxRpcBytes = -1 });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PubsubSettings { MaxRpcBytes = 0 });
+        });
     }
 
     [TestCase(1_025UL)]

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubFrameLimitTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubFrameLimitTests.cs
@@ -10,6 +10,12 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
 [TestFixture]
 public class PubsubFrameLimitTests
 {
+    [Test]
+    public void MaxRpcBytes_RejectsNegativeValues()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PubsubSettings { MaxRpcBytes = -1 });
+    }
+
     [TestCase(1_025UL)]
     [TestCase(2_147_483_648UL)]
     [TestCase(4_294_967_295UL)]

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubFrameLimitTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubFrameLimitTests.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Google.Protobuf;
+using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+using System.Buffers;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
+
+[TestFixture]
+public class PubsubFrameLimitTests
+{
+    [TestCase(1_025UL)]
+    [TestCase(2_147_483_648UL)]
+    [TestCase(4_294_967_295UL)]
+    public async Task ReadPrefixedProtobufAsync_RejectsFramesLargerThanLimit(ulong messageLength)
+    {
+        TestChannel channel = new();
+        Task write = channel.Reverse().WriteAsync(new ReadOnlySequence<byte>(EncodeVarint(messageLength))).AsTask();
+        IChannel reader = channel;
+
+        InvalidDataException? exception = Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await reader.ReadPrefixedProtobufAsync(Rpc.Parser, 1_024));
+
+        Assert.That(exception!.Message, Does.Contain(messageLength.ToString()));
+        await write;
+    }
+
+    [Test]
+    public async Task ReadPrefixedProtobufAsync_RejectsOverflowingVarint()
+    {
+        byte[] overflowedLength = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02];
+        TestChannel channel = new();
+        Task write = channel.Reverse().WriteAsync(new ReadOnlySequence<byte>(overflowedLength)).AsTask();
+        IChannel reader = channel;
+
+        Assert.ThrowsAsync<FormatException>(async () => await reader.ReadPrefixedProtobufAsync(Rpc.Parser, 1_024));
+        await write;
+    }
+
+    private static byte[] EncodeVarint(ulong value)
+    {
+        byte[] bytes = new byte[VarInt.GetSizeInBytes(value)];
+        int offset = 0;
+        VarInt.Encode(value, bytes, ref offset);
+        return bytes;
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubFrameLimitTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubFrameLimitTests.cs
@@ -11,6 +11,17 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
 public class PubsubFrameLimitTests
 {
     [Test]
+    public async Task ReadVarintUlongAsync_WithoutCancellationTokenRemainsAvailable()
+    {
+        TestChannel channel = new();
+        Task write = channel.Reverse().WriteAsync(new ReadOnlySequence<byte>(EncodeVarint(42))).AsTask();
+        IChannel reader = channel;
+
+        Assert.That(await reader.ReadVarintUlongAsync(), Is.EqualTo(42));
+        await write;
+    }
+
+    [Test]
     public void MaxRpcBytes_RejectsNegativeValues()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => new PubsubSettings { MaxRpcBytes = -1 });

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -8,6 +8,8 @@ namespace Nethermind.Libp2p.Protocols.Pubsub;
 
 public class PubsubSettings
 {
+    private int maxRpcBytes = 1 * 1024 * 1024;
+
     public static PubsubSettings Default { get; } = new();
 
     public int ReconnectionAttempts { get; set; } = 10;
@@ -25,7 +27,16 @@ public class PubsubSettings
     public int mcache_len { get; set; } = 5; // Number of history windows in message cache 	5
     public int mcache_gossip { get; set; } = 3; // Number of history windows to use when emitting gossip 	3
     public int MessageCacheTtl { get; set; } = 2 * 60 * 1000; // Expiry time for cache of seen message ids 	2 minutes
-    public int MaxRpcBytes { get; set; } = 1 * 1024 * 1024; // Maximum incoming RPC frame size 1 MiB
+    // Maximum incoming RPC frame size 1 MiB
+    public int MaxRpcBytes
+    {
+        get => maxRpcBytes;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            maxRpcBytes = value;
+        }
+    }
     public SignaturePolicy DefaultSignaturePolicy { get; set; } = SignaturePolicy.StrictSign;
     public int MaxIdontwantMessages { get; set; } = 50;
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -33,7 +33,7 @@ public class PubsubSettings
         get => maxRpcBytes;
         set
         {
-            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
             maxRpcBytes = value;
         }
     }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -25,6 +25,7 @@ public class PubsubSettings
     public int mcache_len { get; set; } = 5; // Number of history windows in message cache 	5
     public int mcache_gossip { get; set; } = 3; // Number of history windows to use when emitting gossip 	3
     public int MessageCacheTtl { get; set; } = 2 * 60 * 1000; // Expiry time for cache of seen message ids 	2 minutes
+    public int MaxRpcBytes { get; set; } = 1 * 1024 * 1024; // Maximum incoming RPC frame size 1 MiB
     public SignaturePolicy DefaultSignaturePolicy { get; set; } = SignaturePolicy.StrictSign;
     public int MaxIdontwantMessages { get; set; } = 50;
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubProtocol.cs
@@ -34,7 +34,7 @@ public abstract class PubsubProtocol : ISessionProtocol
         ArgumentNullException.ThrowIfNull(context.State.RemoteAddress);
         ArgumentNullException.ThrowIfNull(context.State.RemotePeerId);
 
-        PeerId? remotePeerId = context.State.RemotePeerId;
+        PeerId remotePeerId = context.State.RemotePeerId!;
 
         _logger?.LogDebug("Dialed({contextId}) {remoteAddress}", context.Id, context.State.RemoteAddress);
 
@@ -61,7 +61,7 @@ public abstract class PubsubProtocol : ISessionProtocol
         ArgumentNullException.ThrowIfNull(context.State.RemoteAddress);
         ArgumentNullException.ThrowIfNull(context.State.RemotePeerId);
 
-        PeerId? remotePeerId = context.State.RemotePeerId;
+        PeerId remotePeerId = context.State.RemotePeerId!;
 
         _logger?.LogDebug("Listen({contextId}) to {remoteAddress}", context.Id, context.State.RemoteAddress);
 
@@ -75,7 +75,7 @@ public abstract class PubsubProtocol : ISessionProtocol
         {
             while (!token.IsCancellationRequested)
             {
-                Rpc? rpc = await channel.ReadPrefixedProtobufAsync(Rpc.Parser, token);
+                Rpc? rpc = await channel.ReadPrefixedProtobufAsync(Rpc.Parser, router.MaxRpcBytes, token);
                 if (rpc is null)
                 {
                     _logger?.LogDebug("Received a broken message or EOF from {remotePeerId}", remotePeerId);
@@ -89,6 +89,13 @@ public abstract class PubsubProtocol : ISessionProtocol
                     router.OnRpc(remotePeerId, rpc);
                 }
             }
+        }
+        catch (Exception e) when (e is InvalidDataException or FormatException)
+        {
+            _logger?.LogDebug("Invalid RPC from {remotePeerId}: {message}", remotePeerId, e.Message);
+            context.Activity?.AddEvent(new ActivityEvent($"Invalid RPC from {remotePeerId}"));
+            context.Activity?.SetStatus(ActivityStatusCode.Error);
+            await context.DisconnectAsync();
         }
         catch (Exception e)
         {

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubProtocol.cs
@@ -92,7 +92,7 @@ public abstract class PubsubProtocol : ISessionProtocol
         }
         catch (Exception e) when (e is InvalidDataException or FormatException)
         {
-            _logger?.LogDebug("Invalid RPC from {remotePeerId}: {message}", remotePeerId, e.Message);
+            _logger?.LogDebug(e, "Invalid RPC from {remotePeerId}: {message}", remotePeerId, e.Message);
             context.Activity?.AddEvent(new ActivityEvent($"Invalid RPC from {remotePeerId}"));
             context.Activity?.SetStatus(ActivityStatusCode.Error);
             await context.DisconnectAsync();

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubProtocol.cs
@@ -93,7 +93,7 @@ public abstract class PubsubProtocol : ISessionProtocol
         catch (Exception e) when (e is InvalidDataException or FormatException)
         {
             _logger?.LogDebug(e, "Invalid RPC from {remotePeerId}: {message}", remotePeerId, e.Message);
-            context.Activity?.AddEvent(new ActivityEvent($"Invalid RPC from {remotePeerId}"));
+            context.Activity?.AddEvent(new ActivityEvent($"Invalid RPC from {remotePeerId}: {e.Message}"));
             context.Activity?.SetStatus(ActivityStatusCode.Error);
             await context.DisconnectAsync();
         }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -126,6 +126,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     public event Action<string, PeerId, byte[]>? OnMessage;
     public Func<Message, MessageValidity>? VerifyMessage = null;
 
+    internal int MaxRpcBytes => _settings.MaxRpcBytes;
+
     private readonly PubsubSettings _settings;
     private readonly TtlCache<MessageId, MessageWithId> _messageCache;
     private readonly TtlCache<MessageId, MessageWithId> _limboMessageCache;


### PR DESCRIPTION
## Summary
- limit inbound pubsub RPC frames to 1 MiB by default
- reject oversized and overflowing length prefixes before reading a payload
- terminate the session after a malformed pubsub frame
- validate configured frame limits and preserve malformed-frame exceptions in logs

## Pipeline repair
This branch also includes the shared SIPSorcery security dependency update required for CI restore. It aligns the WebRTC certificate integration and is tracked independently in #208.

## Validation
- Added focused frame-limit coverage.