### PR TITLE
Expose TLS remote public keys

### DIFF
--- a/src/libp2p/Libp2p.Protocols.IpTcp/IpTcpProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.IpTcp/IpTcpProtocol.cs
@@ -180,6 +180,10 @@ public class IpTcpProtocol(ILoggerFactory? loggerFactory = null) : ITransportPro
 
         INewConnectionContext connectionCtx = context.CreateConnection();
         connectionCtx.State.RemoteAddress = client.RemoteEndPoint.ToMultiaddress(ProtocolType.Tcp);
+        if (remoteAddr.Get<P2P>() is { } requestedPeerId)
+        {
+            connectionCtx.State.RemoteAddress.Add(requestedPeerId);
+        }
         connectionCtx.State.LocalAddress = client.LocalEndPoint.ToMultiaddress(ProtocolType.Tcp);
 
         connectionCtx.Token.Register(client.Close);

--- a/src/libp2p/Libp2p.Protocols.Noise.Tests/NoiseProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Noise.Tests/NoiseProtocolTests.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Reflection;
 using System.Text;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
@@ -20,6 +21,20 @@ namespace Nethermind.Libp2p.Protocols.Noise.Tests;
 [Parallelizable(scope: ParallelScope.All)]
 public class NoiseProtocolTests
 {
+    [Test]
+    public void Test_RemoteIdentityRejectsUnexpectedDialedPeer()
+    {
+        IConnectionContext context = Substitute.For<IConnectionContext>();
+        context.State.Returns(new State { RemoteAddress = $"/ip4/127.0.0.1/tcp/0/p2p/{TestPeers.PeerId(3)}" });
+
+        MethodInfo setRemoteIdentity = typeof(NoiseProtocol).GetMethod("SetRemoteIdentity", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        TargetInvocationException? exception = Assert.Throws<TargetInvocationException>(() =>
+            setRemoteIdentity.Invoke(null, [context, TestPeers.Identity(2).PublicKey]));
+
+        Assert.That(exception!.InnerException, Is.TypeOf<Libp2pException>());
+    }
+
     [Test]
     public async Task Test_ConnectionEstablished_AfterHandshake()
     {

--- a/src/libp2p/Libp2p.Protocols.Noise/NoiseProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.Noise/NoiseProtocol.cs
@@ -97,9 +97,6 @@ public class NoiseProtocol : IConnectionProtocol
             throw new Libp2pException("Noise handshake signature verification failed: responder identity key does not match noise static key.");
         }
 
-        context.State.RemotePublicKey = msg1KeyDecoded;
-
-
         List<string> responderMuxers = msg1Decoded.Extensions?.StreamMuxers?
             .Where(m => !string.IsNullOrEmpty(m))
             .ToList() ?? [];
@@ -115,11 +112,7 @@ public class NoiseProtocol : IConnectionProtocol
             };
         }
 
-        PeerId remotePeerId = new(msg1KeyDecoded);
-        if (!context.State.RemoteAddress.Has<P2P>())
-        {
-            context.State.RemoteAddress.Add(new P2P(remotePeerId.ToString()));
-        }
+        SetRemoteIdentity(context, msg1KeyDecoded);
 
         byte[] msg = [.. Encoding.UTF8.GetBytes(PayloadSigPrefix), .. ByteString.CopyFrom(clientStatic.PublicKey)];
         byte[] sig = context.Peer.Identity.Sign(msg);
@@ -226,8 +219,6 @@ public class NoiseProtocol : IConnectionProtocol
             throw new Libp2pException("Noise handshake signature verification failed: initiator identity key does not match noise static key.");
         }
 
-        context.State.RemotePublicKey = msg2KeyDecoded;
-
         Transport? transport = msg2.Transport;
 
         List<string> initiatorMuxers = msg2Decoded.Extensions?.StreamMuxers?.Where(m => !string.IsNullOrEmpty(m)).ToList() ?? [];
@@ -245,11 +236,7 @@ public class NoiseProtocol : IConnectionProtocol
             };
         }
 
-        if (!context.State.RemoteAddress.Has<P2P>())
-        {
-            PeerId remotePeerId = new(msg2KeyDecoded);
-            context.State.RemoteAddress.Add(new P2P(remotePeerId.ToString()));
-        }
+        SetRemoteIdentity(context, msg2KeyDecoded);
 
         _logger?.LogDebug("Established connection to {peer}", context.State.RemoteAddress);
 
@@ -260,6 +247,27 @@ public class NoiseProtocol : IConnectionProtocol
         _ = upChannel.CloseAsync();
         _ = downChannel.CloseAsync();
         _logger?.LogDebug("Closed");
+    }
+
+    private static void SetRemoteIdentity(IConnectionContext context, PublicKey remotePublicKey)
+    {
+        if (context.State.RemotePublicKey is { } existingRemotePublicKey && existingRemotePublicKey.ToByteString() != remotePublicKey.ToByteString())
+        {
+            throw new Libp2pException("Noise identity does not match the previously authenticated remote public key.");
+        }
+
+        PeerId remotePeerId = new(remotePublicKey);
+        PeerId? expectedPeerId = context.State.RemoteAddress?.GetPeerId();
+        if (expectedPeerId is not null && expectedPeerId != remotePeerId)
+        {
+            throw new Libp2pException("Noise handshake identity does not match the expected remote peer ID.");
+        }
+
+        context.State.RemotePublicKey = remotePublicKey;
+        if (context.State.RemoteAddress is { } remoteAddress && expectedPeerId is null)
+        {
+            remoteAddress.Add(new P2P(remotePeerId.ToString()));
+        }
     }
 
     private static Task ExchangeData(Transport transport, IChannel downChannel, IChannel upChannel, ILogger? logger)

--- a/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
@@ -67,7 +67,12 @@ public class TlsProtocolTests
         await downChannel.CloseAsync();
 
         // Assert
-        Assert.That(received, Is.EqualTo(sent));
+        Assert.Multiple(() =>
+        {
+            Assert.That(received, Is.EqualTo(sent));
+            Assert.That(new Identity(dialerContext.State.RemotePublicKey!).PeerId, Is.EqualTo(TestPeers.PeerId(2)));
+            Assert.That(new Identity(listenerContext.State.RemotePublicKey!).PeerId, Is.EqualTo(TestPeers.PeerId(1)));
+        });
     }
 
     [Test]

--- a/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
@@ -37,14 +37,14 @@ public class TlsProtocolTests
         IConnectionContext dialerContext = Substitute.For<IConnectionContext>();
         dialerContext.Peer.Identity.Returns(TestPeers.Identity(1));
         dialerContext.Peer.ListenAddresses.Returns([(Multiaddress)$"/ip4/127.0.0.1/tcp/0/p2p/{TestPeers.PeerId(1)}"]);
-        dialerContext.State.Returns(new State { RemoteAddress = $"/p2p/{TestPeers.PeerId(2)}" });
+        dialerContext.State.Returns(new State { RemoteAddress = "/ip4/127.0.0.1/tcp/0" });
         dialerContext.SubProtocols.Returns(Array.Empty<IProtocol>());
         dialerContext.Upgrade(Arg.Any<UpgradeOptions>()).Returns(upChannel);
 
         // Listener context (identity 2 listens for identity 1)
         IConnectionContext listenerContext = Substitute.For<IConnectionContext>();
         listenerContext.Peer.Identity.Returns(TestPeers.Identity(2));
-        listenerContext.State.Returns(new State { RemoteAddress = $"/p2p/{TestPeers.PeerId(1)}" });
+        listenerContext.State.Returns(new State { RemoteAddress = "/ip4/127.0.0.1/tcp/0" });
         listenerContext.SubProtocols.Returns(Array.Empty<IProtocol>());
         listenerContext.Upgrade(Arg.Any<UpgradeOptions>()).Returns(listenerUpChannel);
 
@@ -72,6 +72,8 @@ public class TlsProtocolTests
             Assert.That(received, Is.EqualTo(sent));
             Assert.That(new Identity(dialerContext.State.RemotePublicKey!).PeerId, Is.EqualTo(TestPeers.PeerId(2)));
             Assert.That(new Identity(listenerContext.State.RemotePublicKey!).PeerId, Is.EqualTo(TestPeers.PeerId(1)));
+            Assert.That(dialerContext.State.RemoteAddress!.GetPeerId(), Is.EqualTo(TestPeers.PeerId(2)));
+            Assert.That(listenerContext.State.RemoteAddress!.GetPeerId(), Is.EqualTo(TestPeers.PeerId(1)));
         });
     }
 

--- a/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
@@ -103,6 +103,20 @@ public class TlsProtocolTests
     }
 
     [Test]
+    public void Test_TlsCertificateRejectsUnexpectedDialedPeer()
+    {
+        Identity certificateIdentity = TestPeers.Identity(2);
+        using ECDsa sessionKey = ECDsa.Create();
+        using X509Certificate2 certificate = CertificateHelper.CertificateFromIdentity(sessionKey, certificateIdentity);
+        Multiaddress requestedAddress = $"/ip4/127.0.0.1/tcp/0/p2p/{TestPeers.PeerId(3)}";
+
+        MethodInfo verifyRemoteCertificate = typeof(TlsProtocol).GetMethod("VerifyRemoteCertificate", BindingFlags.Static | BindingFlags.NonPublic)!;
+        bool isValid = (bool)verifyRemoteCertificate.Invoke(null, [requestedAddress, certificate])!;
+
+        Assert.That(isValid, Is.False);
+    }
+
+    [Test]
     public void Test_CertificateFromIdentity_CreatesValidCertificate()
     {
         // Arrange

--- a/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
@@ -11,6 +11,7 @@ using NSubstitute;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -75,6 +76,30 @@ public class TlsProtocolTests
             Assert.That(dialerContext.State.RemoteAddress!.GetPeerId(), Is.EqualTo(TestPeers.PeerId(2)));
             Assert.That(listenerContext.State.RemoteAddress!.GetPeerId(), Is.EqualTo(TestPeers.PeerId(1)));
         });
+    }
+
+    [Test]
+    public void Test_TlsIdentityConflictIsRejected()
+    {
+        Identity certificateIdentity = TestPeers.Identity(2);
+        using ECDsa sessionKey = ECDsa.Create();
+        using X509Certificate2 certificate = CertificateHelper.CertificateFromIdentity(sessionKey, certificateIdentity);
+
+        IConnectionContext context = Substitute.For<IConnectionContext>();
+        State state = new()
+        {
+            RemoteAddress = "/ip4/127.0.0.1/tcp/0",
+            RemotePublicKey = TestPeers.Identity(3).PublicKey,
+        };
+        context.State.Returns(state);
+
+        MethodInfo setRemoteIdentity = typeof(TlsProtocol).GetMethod("SetRemoteIdentity", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        TargetInvocationException? exception = Assert.Throws<TargetInvocationException>(() =>
+            setRemoteIdentity.Invoke(null, [context, certificate]));
+
+        Assert.That(exception!.InnerException, Is.TypeOf<InvalidOperationException>());
+        Assert.That(exception.InnerException!.Message, Does.Contain("does not match"));
     }
 
     [Test]

--- a/src/libp2p/Libp2p.Protocols.Tls/TlsProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.Tls/TlsProtocol.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
+using Google.Protobuf;
 using System.Buffers;
 using System.Net.Security;
 using Nethermind.Libp2p.Protocols.Quic;
@@ -168,7 +169,12 @@ public class TlsProtocol : IConnectionProtocol
         Core.Dto.PublicKey remotePublicKey = CertificateHelper.ExtractPublicKey(certificate, out _)
             ?? throw new InvalidOperationException("Remote public key not found");
 
-        context.State.RemotePublicKey ??= remotePublicKey;
+        if (context.State.RemotePublicKey is { } existingRemotePublicKey && existingRemotePublicKey.ToByteString() != remotePublicKey.ToByteString())
+        {
+            throw new InvalidOperationException("TLS certificate public key does not match the previously authenticated remote public key.");
+        }
+
+        context.State.RemotePublicKey = remotePublicKey;
 
         if (context.State.RemoteAddress is { } remoteAddress && !remoteAddress.Has<P2P>())
         {

--- a/src/libp2p/Libp2p.Protocols.Tls/TlsProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.Tls/TlsProtocol.cs
@@ -58,18 +58,9 @@ public class TlsProtocol : IConnectionProtocol
                 await sslStream.AuthenticateAsServerAsync(serverAuthenticationOptions);
                 LastNegotiatedApplicationProtocol = sslStream.NegotiatedApplicationProtocol;
 
-                // Extract remote peer ID from the client certificate and add it to
-                // RemoteAddress so UpgradeToSession (called by Yamux) can find the peer.
-                if (sslStream.RemoteCertificate is X509Certificate2 remoteCert
-                    && context.State.RemoteAddress is not null
-                    && !context.State.RemoteAddress.Has<P2P>())
+                if (sslStream.RemoteCertificate is X509Certificate2 remoteCert)
                 {
-                    Core.Dto.PublicKey? remotePubKey = CertificateHelper.ExtractPublicKey(remoteCert, out _);
-                    if (remotePubKey != null)
-                    {
-                        Identity remoteIdentity = new(remotePubKey);
-                        context.State.RemoteAddress.Add(new P2P(remoteIdentity.PeerId.ToString()));
-                    }
+                    SetRemoteIdentity(context, remoteCert);
                 }
 
                 _logger?.LogInformation("Server TLS Authentication successful. PeerId: {RemotePeerId}, NegotiatedProtocol: {Protocol}.", context.State.RemotePeerId, LastNegotiatedApplicationProtocol.HasValue ? System.Text.Encoding.UTF8.GetString(LastNegotiatedApplicationProtocol.Value.Protocol.ToArray()) : "None");
@@ -144,19 +135,9 @@ public class TlsProtocol : IConnectionProtocol
 
                 LastNegotiatedApplicationProtocol = sslStream.NegotiatedApplicationProtocol;
 
-                // Extract remote peer ID from the server certificate and add it to
-                // RemoteAddress so UpgradeToSession (called by Yamux) can find the peer.
-                // (TCP protocol only sets /ip4/.../tcp/... address without /p2p/... component.)
-                if (sslStream.RemoteCertificate is X509Certificate2 remoteCert
-                    && context.State.RemoteAddress is not null
-                    && !context.State.RemoteAddress.Has<P2P>())
+                if (sslStream.RemoteCertificate is X509Certificate2 remoteCert)
                 {
-                    Core.Dto.PublicKey? remotePubKey = CertificateHelper.ExtractPublicKey(remoteCert, out _);
-                    if (remotePubKey != null)
-                    {
-                        Identity remoteIdentity = new(remotePubKey);
-                        context.State.RemoteAddress.Add(new P2P(remoteIdentity.PeerId.ToString()));
-                    }
+                    SetRemoteIdentity(context, remoteCert);
                 }
 
                 _logger?.LogInformation("Client TLS Authentication successful. RemotePeerId: {RemotePeerId}, NegotiatedProtocol: {Protocol}.", context.State.RemotePeerId, LastNegotiatedApplicationProtocol.HasValue ? System.Text.Encoding.UTF8.GetString(LastNegotiatedApplicationProtocol.Value.Protocol.ToArray()) : "None");
@@ -179,6 +160,19 @@ public class TlsProtocol : IConnectionProtocol
         {
             _logger?.LogError(ex, "Error during TLS protocol negotiation.");
             throw;
+        }
+    }
+
+    private static void SetRemoteIdentity(IConnectionContext context, X509Certificate2 certificate)
+    {
+        Core.Dto.PublicKey remotePublicKey = CertificateHelper.ExtractPublicKey(certificate, out _)
+            ?? throw new InvalidOperationException("Remote public key not found");
+
+        context.State.RemotePublicKey ??= remotePublicKey;
+
+        if (context.State.RemoteAddress is { } remoteAddress && !remoteAddress.Has<P2P>())
+        {
+            remoteAddress.Add(new P2P(new Identity(remotePublicKey).PeerId.ToString()));
         }
     }
 


### PR DESCRIPTION
## Summary
- record the authenticated certificate key in connection state for both TLS roles
- retain peer-address enrichment when a connection starts without a /p2p component
- reject a certificate key that conflicts with an already authenticated identity
- cover the public-key state and peer-address enrichment produced by a TLS handshake

## Pipeline repair
This branch also includes the shared SIPSorcery security dependency update required for CI restore. It aligns the WebRTC certificate integration and is tracked independently in #208.

## Validation
- Extended the TLS handshake coverage.