### PR TITLE
Repair pubsub topic lifecycle

### DIFF
--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
@@ -86,7 +86,7 @@ public class TopicLifecycleTests
     }
 
     [Test]
-    public void Topic_UnsubscribeNotifiesAllConnectedPeersAndIsNotReadvertised()
+    public void Topic_UnsubscribeNotifiesAllConnectedPeersAndDoesNotAnnounceItToNewPeers()
     {
         const string topicName = "topic-lifecycle";
         PubsubRouter router = new(new PeerStore());

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
@@ -121,6 +121,40 @@ public class TopicLifecycleTests
         thirdConnectionClosed.SetResult();
     }
 
+    [Test]
+    public async Task PublishOnlyTopic_ContinuesGossiping()
+    {
+        const string topicName = "topic-lifecycle";
+        PubsubSettings settings = new() { Degree = 1, LazyDegree = 1, GossipFactor = 1 };
+        PubsubRouter router = new(new PeerStore(), settings);
+        IRoutingStateContainer state = router;
+        _ = router.GetTopic(topicName, subscribe: false);
+        Multiaddress fanoutPeerAddress = TestPeers.Multiaddr(3);
+        Multiaddress gossipPeerAddress = TestPeers.Multiaddr(4);
+        PeerId fanoutPeerId = fanoutPeerAddress.GetPeerId()!;
+        PeerId gossipPeerId = gossipPeerAddress.GetPeerId()!;
+        TaskCompletionSource fanoutConnectionClosed = new();
+        TaskCompletionSource gossipConnectionClosed = new();
+        List<Rpc> fanoutSent = [];
+        List<Rpc> gossipSent = [];
+
+        router.OutboundConnection(fanoutPeerAddress, PubsubRouter.GossipsubProtocolVersionV11, fanoutConnectionClosed.Task, fanoutSent.Add);
+        router.OutboundConnection(gossipPeerAddress, PubsubRouter.GossipsubProtocolVersionV11, gossipConnectionClosed.Task, gossipSent.Add);
+        router.OnRpc(fanoutPeerId, new Rpc().WithTopics([topicName], []));
+        router.OnRpc(gossipPeerId, new Rpc().WithTopics([topicName], []));
+        state.Fanout.GetOrAdd(topicName, []).Add(fanoutPeerId);
+        router.OnRpc(fanoutPeerId, CreateMessage(topicName, TestPeers.Identity(5), 1));
+        fanoutSent.Clear();
+        gossipSent.Clear();
+
+        await state.Heartbeat();
+
+        Assert.That(gossipSent.Any(rpc => rpc.Control?.Ihave.Any(ihave => ihave.TopicID == topicName) is true), Is.True);
+
+        fanoutConnectionClosed.SetResult();
+        gossipConnectionClosed.SetResult();
+    }
+
     private static Rpc CreateMessage(string topicName, Identity author, ulong sequenceNumber)
     {
         return new Rpc().WithMessages(topicName, sequenceNumber, author.PeerId.Bytes, [1, 2, 3], author);

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
@@ -57,6 +57,7 @@ public class TopicLifecycleTests
 
         router.OutboundConnection(peerAddress, PubsubRouter.GossipsubProtocolVersionV11, connectionClosed.Task, sent.Add);
         router.OnRpc(peerId, new Rpc().WithTopics([topicName], []));
+        router.OnRpc(peerId, CreateMessage(topicName, TestPeers.Identity(2), 1));
         sent.Clear();
 
         topic.Unsubscribe();
@@ -68,6 +69,9 @@ public class TopicLifecycleTests
         });
 
         sent.Clear();
+        await state.Heartbeat();
+        Assert.That(sent, Is.Empty);
+
         topic.Subscribe();
         await state.Heartbeat();
 
@@ -79,6 +83,42 @@ public class TopicLifecycleTests
         });
 
         connectionClosed.SetResult();
+    }
+
+    [Test]
+    public void Topic_UnsubscribeNotifiesAllConnectedPeersAndIsNotReadvertised()
+    {
+        const string topicName = "topic-lifecycle";
+        PubsubRouter router = new(new PeerStore());
+        ITopic topic = router.GetTopic(topicName);
+        TaskCompletionSource firstConnectionClosed = new();
+        TaskCompletionSource secondConnectionClosed = new();
+        TaskCompletionSource thirdConnectionClosed = new();
+        List<Rpc> firstSent = [];
+        List<Rpc> secondSent = [];
+        List<Rpc> thirdSent = [];
+        Multiaddress firstPeerAddress = TestPeers.Multiaddr(3);
+
+        router.OutboundConnection(firstPeerAddress, PubsubRouter.GossipsubProtocolVersionV11, firstConnectionClosed.Task, firstSent.Add);
+        router.OutboundConnection(TestPeers.Multiaddr(4), PubsubRouter.GossipsubProtocolVersionV11, secondConnectionClosed.Task, secondSent.Add);
+        router.OnRpc(firstPeerAddress.GetPeerId()!, new Rpc().WithTopics([topicName], []));
+        firstSent.Clear();
+        secondSent.Clear();
+
+        topic.Unsubscribe();
+
+        router.OutboundConnection(TestPeers.Multiaddr(5), PubsubRouter.GossipsubProtocolVersionV11, thirdConnectionClosed.Task, thirdSent.Add);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstSent.Any(rpc => rpc.Subscriptions.Any(subscription => !subscription.Subscribe && subscription.Topicid == topicName)), Is.True);
+            Assert.That(secondSent.Any(rpc => rpc.Subscriptions.Any(subscription => !subscription.Subscribe && subscription.Topicid == topicName)), Is.True);
+            Assert.That(thirdSent.Any(rpc => rpc.Subscriptions.Any(subscription => subscription.Subscribe && subscription.Topicid == topicName)), Is.False);
+        });
+
+        firstConnectionClosed.SetResult();
+        secondConnectionClosed.SetResult();
+        thirdConnectionClosed.SetResult();
     }
 
     private static Rpc CreateMessage(string topicName, Identity author, ulong sequenceNumber)

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Multiformats.Address;
+using Nethermind.Libp2p.Core.Discovery;
+using Nethermind.Libp2p.Protocols.Pubsub;
+using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
+
+[TestFixture]
+public class TopicLifecycleTests
+{
+    [Test]
+    public void Topic_UnsubscribeStopsDeliveryUntilResubscribed()
+    {
+        const string topicName = "topic-lifecycle";
+        PeerStore peerStore = new();
+        PubsubRouter router = new(peerStore);
+        ITopic topic = router.GetTopic(topicName);
+        PeerId receivedFrom = TestPeers.PeerId(1);
+        Identity author = TestPeers.Identity(2);
+        int deliveries = 0;
+        topic.OnMessage += (_, _) => deliveries++;
+
+        topic.Unsubscribe();
+        router.OnRpc(receivedFrom, CreateMessage(topicName, author, 1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(topic.IsSubscribed, Is.False);
+            Assert.That(deliveries, Is.Zero);
+        });
+
+        topic.Subscribe();
+        router.OnRpc(receivedFrom, CreateMessage(topicName, author, 2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(topic.IsSubscribed, Is.True);
+            Assert.That(deliveries, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task Topic_ResubscribeRetainsRemoteMembership()
+    {
+        const string topicName = "topic-lifecycle";
+        PeerStore peerStore = new();
+        PubsubRouter router = new(peerStore);
+        IRoutingStateContainer state = router;
+        ITopic topic = router.GetTopic(topicName);
+        Multiaddress peerAddress = TestPeers.Multiaddr(3);
+        PeerId peerId = peerAddress.GetPeerId()!;
+        TaskCompletionSource connectionClosed = new();
+        List<Rpc> sent = [];
+
+        router.OutboundConnection(peerAddress, PubsubRouter.GossipsubProtocolVersionV11, connectionClosed.Task, sent.Add);
+        router.OnRpc(peerId, new Rpc().WithTopics([topicName], []));
+        sent.Clear();
+
+        topic.Unsubscribe();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.GossipsubPeers[topicName], Has.Member(peerId));
+            Assert.That(state.Mesh, Does.Not.ContainKey(topicName));
+        });
+
+        sent.Clear();
+        topic.Subscribe();
+        await state.Heartbeat();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.GossipsubPeers[topicName], Has.Member(peerId));
+            Assert.That(state.Mesh[topicName], Has.Member(peerId));
+            Assert.That(sent.Any(rpc => rpc.Subscriptions.Any(subscription => subscription.Subscribe && subscription.Topicid == topicName)), Is.True);
+        });
+
+        connectionClosed.SetResult();
+    }
+
+    private static Rpc CreateMessage(string topicName, Identity author, ulong sequenceNumber)
+    {
+        return new Rpc().WithMessages(topicName, sequenceNumber, author.PeerId.Bytes, [1, 2, 3], author);
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
@@ -179,6 +179,25 @@ public class TopicLifecycleTests
         connectionClosed.SetResult();
     }
 
+    [Test]
+    public void Topic_SubscribeMovesFanoutPeersIntoTheMesh()
+    {
+        const string topicName = "topic-lifecycle";
+        PubsubRouter router = new(new PeerStore());
+        IRoutingStateContainer state = router;
+        ITopic topic = router.GetTopic(topicName, subscribe: false);
+        PeerId fanoutPeer = TestPeers.PeerId(3);
+        state.Fanout.GetOrAdd(topicName, []).Add(fanoutPeer);
+
+        topic.Subscribe();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.Mesh[topicName], Has.Member(fanoutPeer));
+            Assert.That(state.Fanout, Does.Not.ContainKey(topicName));
+        });
+    }
+
     private static Rpc CreateMessage(string topicName, Identity author, ulong sequenceNumber)
     {
         return new Rpc().WithMessages(topicName, sequenceNumber, author.PeerId.Bytes, [1, 2, 3], author);

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
+using Google.Protobuf;
 using Multiformats.Address;
 using Nethermind.Libp2p.Core.Discovery;
 using Nethermind.Libp2p.Protocols.Pubsub;
@@ -153,6 +154,29 @@ public class TopicLifecycleTests
 
         fanoutConnectionClosed.SetResult();
         gossipConnectionClosed.SetResult();
+    }
+
+    [Test]
+    public void UnsubscribedTopic_DoesNotRequestAdvertisedMessages()
+    {
+        const string topicName = "topic-lifecycle";
+        PubsubRouter router = new(new PeerStore());
+        ITopic topic = router.GetTopic(topicName);
+        Multiaddress peerAddress = TestPeers.Multiaddr(3);
+        TaskCompletionSource connectionClosed = new();
+        List<Rpc> sent = [];
+
+        router.OutboundConnection(peerAddress, PubsubRouter.GossipsubProtocolVersionV11, connectionClosed.Task, sent.Add);
+        topic.Unsubscribe();
+        sent.Clear();
+
+        Rpc rpc = new() { Control = new ControlMessage() };
+        rpc.Control.Ihave.Add(new ControlIHave { TopicID = topicName, MessageIDs = { ByteString.CopyFrom([1]) } });
+        router.OnRpc(peerAddress.GetPeerId()!, rpc);
+
+        Assert.That(sent, Is.Empty);
+
+        connectionClosed.SetResult();
     }
 
     private static Rpc CreateMessage(string topicName, Identity author, ulong sequenceNumber)

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
@@ -157,6 +157,28 @@ public class TopicLifecycleTests
     }
 
     [Test]
+    public async Task PublishWithoutSubscriptionUsesGossipsubFanout()
+    {
+        const string topicName = "topic-lifecycle";
+        PubsubRouter router = new(new PeerStore());
+        await router.StartAsync(new LocalPeerStub());
+        _ = router.GetTopic(topicName, subscribe: false);
+        Multiaddress peerAddress = TestPeers.Multiaddr(3);
+        PeerId peerId = peerAddress.GetPeerId()!;
+        TaskCompletionSource connectionClosed = new();
+        List<Rpc> sent = [];
+
+        router.OutboundConnection(peerAddress, PubsubRouter.GossipsubProtocolVersionV11, connectionClosed.Task, sent.Add);
+        router.OnRpc(peerId, new Rpc().WithTopics([topicName], []));
+        sent.Clear();
+
+        router.Publish(topicName, [1, 2, 3]);
+
+        Assert.That(sent.SelectMany(rpc => rpc.Publish).Count(), Is.EqualTo(1));
+        connectionClosed.SetResult();
+    }
+
+    [Test]
     public void UnsubscribedTopic_DoesNotRequestAdvertisedMessages()
     {
         const string topicName = "topic-lifecycle";

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -210,10 +210,10 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     {
         foreach (ControlGraft? graft in grafts)
         {
-            if (!topicState.ContainsKey(graft.TopicID))
+            if (topicState.GetValueOrDefault(graft.TopicID)?.IsSubscribed is not true ||
+                !mesh.TryGetValue(graft.TopicID, out HashSet<PeerId>? topicMesh))
             {
-                // Ignore GRAFT for unknown topics (spam protection)
-                logger?.LogDebug("Ignoring GRAFT from {peerId} for unknown topic {topic}", peerId, graft.TopicID);
+                logger?.LogDebug("Ignoring GRAFT from {peerId} for inactive topic {topic}", peerId, graft.TopicID);
                 continue;
             }
 
@@ -232,8 +232,6 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     continue;
                 }
             }
-
-            HashSet<PeerId> topicMesh = mesh[graft.TopicID];
 
             if (topicMesh.Count >= _settings.HighestDegree)
             {
@@ -278,14 +276,16 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     {
         foreach (ControlPrune? prune in prunes)
         {
-            if (topicState.ContainsKey(prune.TopicID) && mesh[prune.TopicID].Contains(peerId))
+            if (topicState.GetValueOrDefault(prune.TopicID)?.IsSubscribed is true &&
+                mesh.TryGetValue(prune.TopicID, out HashSet<PeerId>? topicMesh) &&
+                topicMesh.Contains(peerId))
             {
                 if (peerState.TryGetValue(peerId, out PubsubPeer? state))
                 {
                     ulong backoffSeconds = prune.Backoff == 0 ? (ulong)(_settings.PruneBackoff / 1000) : prune.Backoff;
                     state.Backoff[prune.TopicID] = DateTime.Now.AddSeconds(backoffSeconds);
                 }
-                mesh[prune.TopicID].Remove(peerId);
+                topicMesh.Remove(peerId);
                 RecordPeerLeaveMesh(peerId, prune.TopicID);  // Track for scoring (P1 and P3b)
 
                 // Handle PX (Peer Exchange) only if peer score is above threshold
@@ -306,7 +306,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     {
         List<MessageId> messageIds = [];
 
-        foreach (ControlIHave? ihave in ihaves.Where(iw => topicState.ContainsKey(iw.TopicID)))
+        foreach (ControlIHave? ihave in ihaves.Where(iw => topicState.GetValueOrDefault(iw.TopicID)?.IsSubscribed is true))
         {
             messageIds.AddRange(ihave.MessageIDs.Select(m => new MessageId(m.ToByteArray()))
                 .Where(mid => !_messageCache.Contains(mid)));

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.Logging;
 using Nethermind.Libp2p.Core;
 using Nethermind.Libp2p.Protocols.Pubsub.Dto;
-using System.Buffers.Binary;
 using System.Collections.Concurrent;
 
 namespace Nethermind.Libp2p.Protocols.Pubsub;
@@ -119,37 +118,24 @@ public partial class PubsubRouter
             throw new InvalidOperationException("Router has not been started. Call StartAsync() first.");
         }
 
-        topicState.GetOrAdd(topicId, (id) => new Topic(this, topicId));
-
-        ulong seqNo = this.seqNo++;
-        Span<byte> seqNoBytes = stackalloc byte[8];
-        BinaryPrimitives.WriteUInt64BigEndian(seqNoBytes, seqNo);
-        Rpc rpc = new Rpc().WithMessages(topicId, seqNo, localPeer.Identity.PeerId.Bytes, message, localPeer.Identity);
-
-        // Floodsub peers always get the message
-        foreach (PeerId peerId in fPeers[topicId])
+        lock (this)
         {
-            peerState.GetValueOrDefault(peerId)?.Send(rpc);
-        }
+            topicState.GetOrAdd(topicId, (id) => new Topic(this, topicId));
 
-        // Gossipsub v1.1: Flood publishing
-        if (_settings.FloodPublish && gPeers.TryGetValue(topicId, out HashSet<PeerId>? allGossipsubPeers))
-        {
-            // Send to all gossipsub peers above publish threshold
-            foreach (PeerId peerId in allGossipsubPeers)
+            ulong seqNo = this.seqNo++;
+            Rpc rpc = new Rpc().WithMessages(topicId, seqNo, localPeer.Identity.PeerId.Bytes, message, localPeer.Identity);
+
+            // Floodsub peers always get the message
+            foreach (PeerId peerId in fPeers.GetValueOrDefault(topicId) ?? [])
             {
-                if (GetPeerScore(peerId) >= _settings.PublishThreshold)
-                {
-                    peerState.GetValueOrDefault(peerId)?.Send(rpc);
-                }
+                peerState.GetValueOrDefault(peerId)?.Send(rpc);
             }
-        }
-        else
-        {
-            // Standard gossipsub v1.0 behavior: send to mesh or fanout
-            if (mesh.ContainsKey(topicId))
+
+            // Gossipsub v1.1: Flood publishing
+            if (_settings.FloodPublish && gPeers.TryGetValue(topicId, out HashSet<PeerId>? allGossipsubPeers))
             {
-                foreach (PeerId peerId in mesh[topicId].ToList())
+                // Send to all gossipsub peers above publish threshold
+                foreach (PeerId peerId in allGossipsubPeers)
                 {
                     if (GetPeerScore(peerId) >= _settings.PublishThreshold)
                     {
@@ -159,28 +145,42 @@ public partial class PubsubRouter
             }
             else
             {
-                fanoutLastPublished[topicId] = DateTime.Now;
-                HashSet<PeerId> topicFanout = fanout.GetOrAdd(topicId, _ => []);
-
-                if (topicFanout.Count == 0)
+                // Standard gossipsub v1.0 behavior: send to mesh or fanout
+                if (mesh.TryGetValue(topicId, out HashSet<PeerId>? meshPeers))
                 {
-                    HashSet<PeerId>? topicPeers = gPeers.GetValueOrDefault(topicId);
-                    if (topicPeers is { Count: > 0 })
+                    foreach (PeerId peerId in meshPeers)
                     {
-                        // Select peers with non-negative scores
-                        var eligiblePeers = topicPeers.Where(p => GetPeerScore(p) >= 0).ToList();
-                        foreach (PeerId peer in eligiblePeers.Take(_settings.Degree))
+                        if (GetPeerScore(peerId) >= _settings.PublishThreshold)
                         {
-                            topicFanout.Add(peer);
+                            peerState.GetValueOrDefault(peerId)?.Send(rpc);
                         }
                     }
                 }
-
-                foreach (PeerId peerId in topicFanout)
+                else
                 {
-                    if (GetPeerScore(peerId) >= _settings.PublishThreshold)
+                    fanoutLastPublished[topicId] = DateTime.Now;
+                    HashSet<PeerId> topicFanout = fanout.GetOrAdd(topicId, _ => []);
+
+                    if (topicFanout.Count == 0)
                     {
-                        peerState.GetValueOrDefault(peerId)?.Send(rpc);
+                        HashSet<PeerId>? topicPeers = gPeers.GetValueOrDefault(topicId);
+                        if (topicPeers is { Count: > 0 })
+                        {
+                            // Select peers with non-negative scores
+                            var eligiblePeers = topicPeers.Where(p => GetPeerScore(p) >= 0).ToList();
+                            foreach (PeerId peer in eligiblePeers.Take(_settings.Degree))
+                            {
+                                topicFanout.Add(peer);
+                            }
+                        }
+                    }
+
+                    foreach (PeerId peerId in topicFanout)
+                    {
+                        if (GetPeerScore(peerId) >= _settings.PublishThreshold)
+                        {
+                            peerState.GetValueOrDefault(peerId)?.Send(rpc);
+                        }
                     }
                 }
             }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -27,14 +27,15 @@ public partial class PubsubRouter
 
     public void Subscribe(string topicId)
     {
-        topicState.GetOrAdd(topicId, (id) => new Topic(this, topicId)).IsSubscribed = true;
-
-        if (!fPeers.TryAdd(topicId, []))
+        Topic topic = topicState.GetOrAdd(topicId, (id) => new Topic(this, topicId));
+        if (topic.IsSubscribed)
         {
-            // Already exists
             return;
         }
 
+        topic.IsSubscribed = true;
+
+        fPeers.TryAdd(topicId, []);
         gPeers.TryAdd(topicId, []);
 
         HashSet<PeerId> meshPeers = mesh.GetOrAdd(topicId, []);
@@ -58,9 +59,14 @@ public partial class PubsubRouter
 
     public void Unsubscribe(string topicId)
     {
-        topicState.GetOrAdd(topicId, (id) => new Topic(this, topicId)).IsSubscribed = false;
+        if (!topicState.TryGetValue(topicId, out Topic? topic) || !topic.IsSubscribed)
+        {
+            return;
+        }
 
-        foreach (PeerId peerId in fPeers[topicId])
+        topic.IsSubscribed = false;
+
+        foreach (PeerId peerId in fPeers.GetValueOrDefault(topicId) ?? [])
         {
             Rpc msg = new Rpc()
                 .WithTopics([], [topicId]);
@@ -68,7 +74,7 @@ public partial class PubsubRouter
             peerState.GetValueOrDefault(peerId)?.Send(msg);
         }
 
-        foreach (PeerId peerId in gPeers[topicId])
+        foreach (PeerId peerId in gPeers.GetValueOrDefault(topicId) ?? [])
         {
             Rpc msg = new Rpc()
                 .WithTopics([], [topicId]);
@@ -79,45 +85,27 @@ public partial class PubsubRouter
             }
             peerState.GetValueOrDefault(peerId)?.Send(msg);
         }
+
+        if (mesh.TryRemove(topicId, out HashSet<PeerId>? removedMesh))
+        {
+            foreach (PeerId peerId in removedMesh)
+            {
+                RecordPeerLeaveMesh(peerId, topicId);
+            }
+        }
+
+        fanout.TryRemove(topicId, out _);
+        fanoutLastPublished.TryRemove(topicId, out _);
     }
 
     public void UnsubscribeAll()
     {
-        try
+        foreach (string topicId in topicState
+            .Where(pair => pair.Value.IsSubscribed)
+            .Select(pair => pair.Key)
+            .ToArray())
         {
-            foreach (PeerId? peerId in fPeers.SelectMany(kv => kv.Value))
-            {
-                Rpc msg = new Rpc().WithTopics([], topicState.Keys);
-
-                peerState.GetValueOrDefault(peerId)?.Send(msg);
-            }
-
-            Dictionary<PeerId, Rpc> peerMessages = [];
-
-            foreach (PeerId? peerId in gPeers.SelectMany(kv => kv.Value))
-            {
-                (peerMessages[peerId] ??= new Rpc())
-                    .WithTopics([], topicState.Keys);
-            }
-
-            foreach (KeyValuePair<string, HashSet<PeerId>> topicMesh in mesh.ToDictionary())
-            {
-                foreach (PeerId peerId in topicMesh.Value)
-                {
-                    (peerMessages[peerId] ??= new Rpc())
-                       .Ensure(r => r.Control.Prune)
-                       .Add(new ControlPrune { TopicID = topicMesh.Key });
-                }
-            }
-
-            foreach (KeyValuePair<PeerId, Rpc> peerMessage in peerMessages)
-            {
-                peerState.GetValueOrDefault(peerMessage.Key)?.Send(peerMessage.Value);
-            }
-        }
-        catch (Exception e)
-        {
-            logger?.LogError(e, $"Error during {nameof(UnsubscribeAll)}");
+            Unsubscribe(topicId);
         }
     }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -43,14 +43,14 @@ public partial class PubsubRouter
 
             HashSet<PeerId> meshPeers = mesh.GetOrAdd(topicId, []);
 
-            if (fanout.TryGetValue(topicId, out HashSet<PeerId>? fanoutPeers))
+            if (fanout.TryRemove(topicId, out HashSet<PeerId>? fanoutPeers))
             {
                 foreach (PeerId peerId in fanoutPeers.ToList())
                 {
                     meshPeers.Add(peerId);
                 }
 
-                fanoutPeers.Clear();
+                fanoutLastPublished.TryRemove(topicId, out _);
             }
 
             peers = peerState.Values.ToArray();

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -27,75 +27,78 @@ public partial class PubsubRouter
 
     public void Subscribe(string topicId)
     {
-        Topic topic = topicState.GetOrAdd(topicId, (id) => new Topic(this, topicId));
-        if (topic.IsSubscribed)
+        PubsubPeer[] peers;
+        lock (this)
         {
-            return;
-        }
-
-        topic.IsSubscribed = true;
-
-        fPeers.TryAdd(topicId, []);
-        gPeers.TryAdd(topicId, []);
-
-        HashSet<PeerId> meshPeers = mesh.GetOrAdd(topicId, []);
-
-        if (fanout.TryGetValue(topicId, out HashSet<PeerId>? fanoutPeers))
-        {
-            foreach (PeerId peerId in fanoutPeers.ToList())
+            Topic topic = topicState.GetOrAdd(topicId, (id) => new Topic(this, topicId));
+            if (topic.IsSubscribed)
             {
-                meshPeers.Add(peerId);
+                return;
             }
 
-            fanoutPeers.Clear();
+            topic.IsSubscribed = true;
+
+            fPeers.TryAdd(topicId, []);
+            gPeers.TryAdd(topicId, []);
+
+            HashSet<PeerId> meshPeers = mesh.GetOrAdd(topicId, []);
+
+            if (fanout.TryGetValue(topicId, out HashSet<PeerId>? fanoutPeers))
+            {
+                foreach (PeerId peerId in fanoutPeers.ToList())
+                {
+                    meshPeers.Add(peerId);
+                }
+
+                fanoutPeers.Clear();
+            }
+
+            peers = peerState.Values.ToArray();
         }
 
         Rpc topicUpdate = new Rpc().WithTopics([topicId], []);
-        foreach (KeyValuePair<PeerId, PubsubPeer> peer in peerState)
+        foreach (PubsubPeer peer in peers)
         {
-            peer.Value.Send(topicUpdate);
+            peer.Send(topicUpdate);
         }
     }
 
     public void Unsubscribe(string topicId)
     {
-        if (!topicState.TryGetValue(topicId, out Topic? topic) || !topic.IsSubscribed)
+        KeyValuePair<PeerId, PubsubPeer>[] peers;
+        HashSet<PeerId>? removedMesh;
+        lock (this)
         {
-            return;
+            if (!topicState.TryGetValue(topicId, out Topic? topic) || !topic.IsSubscribed)
+            {
+                return;
+            }
+
+            topic.IsSubscribed = false;
+
+            if (mesh.TryRemove(topicId, out removedMesh))
+            {
+                foreach (PeerId peerId in removedMesh)
+                {
+                    RecordPeerLeaveMesh(peerId, topicId);
+                }
+            }
+
+            fanout.TryRemove(topicId, out _);
+            fanoutLastPublished.TryRemove(topicId, out _);
+            peers = peerState.ToArray();
         }
 
-        topic.IsSubscribed = false;
-
-        foreach (PeerId peerId in fPeers.GetValueOrDefault(topicId) ?? [])
+        foreach ((PeerId peerId, PubsubPeer peer) in peers)
         {
-            Rpc msg = new Rpc()
-                .WithTopics([], [topicId]);
-
-            peerState.GetValueOrDefault(peerId)?.Send(msg);
-        }
-
-        foreach (PeerId peerId in gPeers.GetValueOrDefault(topicId) ?? [])
-        {
-            Rpc msg = new Rpc()
-                .WithTopics([], [topicId]);
-
-            if (mesh.TryGetValue(topicId, out HashSet<PeerId>? topicMesh) && topicMesh.Contains(peerId))
+            Rpc msg = new Rpc().WithTopics([], [topicId]);
+            if (removedMesh?.Contains(peerId) is true)
             {
                 msg.Ensure(r => r.Control.Prune).Add(new ControlPrune { TopicID = topicId });
             }
-            peerState.GetValueOrDefault(peerId)?.Send(msg);
-        }
 
-        if (mesh.TryRemove(topicId, out HashSet<PeerId>? removedMesh))
-        {
-            foreach (PeerId peerId in removedMesh)
-            {
-                RecordPeerLeaveMesh(peerId, topicId);
-            }
+            peer.Send(msg);
         }
-
-        fanout.TryRemove(topicId, out _);
-        fanoutLastPublished.TryRemove(topicId, out _);
     }
 
     public void UnsubscribeAll()

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -27,7 +27,6 @@ public partial class PubsubRouter
 
     public void Subscribe(string topicId)
     {
-        PubsubPeer[] peers;
         lock (this)
         {
             Topic topic = topicState.GetOrAdd(topicId, (id) => new Topic(this, topicId));
@@ -47,25 +46,25 @@ public partial class PubsubRouter
             {
                 foreach (PeerId peerId in fanoutPeers.ToList())
                 {
-                    meshPeers.Add(peerId);
+                    if (meshPeers.Add(peerId))
+                    {
+                        RecordPeerJoinMesh(peerId, topicId);
+                    }
                 }
 
                 fanoutLastPublished.TryRemove(topicId, out _);
             }
 
-            peers = peerState.Values.ToArray();
-        }
-
-        Rpc topicUpdate = new Rpc().WithTopics([topicId], []);
-        foreach (PubsubPeer peer in peers)
-        {
-            peer.Send(topicUpdate);
+            Rpc topicUpdate = new Rpc().WithTopics([topicId], []);
+            foreach (PubsubPeer peer in peerState.Values)
+            {
+                peer.Send(topicUpdate);
+            }
         }
     }
 
     public void Unsubscribe(string topicId)
     {
-        KeyValuePair<PeerId, PubsubPeer>[] peers;
         HashSet<PeerId>? removedMesh;
         lock (this)
         {
@@ -86,18 +85,16 @@ public partial class PubsubRouter
 
             fanout.TryRemove(topicId, out _);
             fanoutLastPublished.TryRemove(topicId, out _);
-            peers = peerState.ToArray();
-        }
-
-        foreach ((PeerId peerId, PubsubPeer peer) in peers)
-        {
-            Rpc msg = new Rpc().WithTopics([], [topicId]);
-            if (removedMesh?.Contains(peerId) is true)
+            foreach ((PeerId peerId, PubsubPeer peer) in peerState)
             {
-                msg.Ensure(r => r.Control.Prune).Add(new ControlPrune { TopicID = topicId });
-            }
+                Rpc msg = new Rpc().WithTopics([], [topicId]);
+                if (removedMesh?.Contains(peerId) is true)
+                {
+                    msg.Ensure(r => r.Control.Prune).Add(new ControlPrune { TopicID = topicId });
+                }
 
-            peer.Send(msg);
+                peer.Send(msg);
+            }
         }
     }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -422,11 +422,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             IEnumerable<IGrouping<string, MessageWithId>> msgs = _messageCache.ToList().GroupBy(m => m.Message.Topic);
 
             foreach (string topic in gPeers.Keys.Concat(fanout.Keys).Distinct()
-                .Where(topic => topicState.GetValueOrDefault(topic)?.IsSubscribed is true)
+                .Where(topic => topicState.GetValueOrDefault(topic)?.IsSubscribed is true || fanout.ContainsKey(topic))
                 .ToArray())
             {
                 IGrouping<string, MessageWithId>? msgsInTopic = msgs.FirstOrDefault(mit => mit.Key == topic);
-                if (msgsInTopic is not null)
+                if (msgsInTopic is not null && gPeers.TryGetValue(topic, out HashSet<PeerId>? topicGossipsubPeers))
                 {
                     ControlIHave ihave = new() { TopicID = topic };
                     ihave.MessageIDs.AddRange(msgsInTopic.Select(m => ByteString.CopyFrom(m.Id.Bytes)));
@@ -434,7 +434,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     // Only send gossip to peers above gossip threshold
                     HashSet<PeerId>? topicMesh = mesh.GetValueOrDefault(topic);
                     HashSet<PeerId>? topicFanout = fanout.GetValueOrDefault(topic);
-                    var eligiblePeers = gPeers[topic]
+                    var eligiblePeers = topicGossipsubPeers
                         .Where(p => !(topicMesh?.Contains(p) ?? false)
                             && !(topicFanout?.Contains(p) ?? false)
                             && GetPeerScore(p) >= _settings.GossipThreshold);

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -421,7 +421,9 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
             IEnumerable<IGrouping<string, MessageWithId>> msgs = _messageCache.ToList().GroupBy(m => m.Message.Topic);
 
-            foreach (string? topic in gPeers.Keys.Concat(fanout.Keys).Distinct().ToArray())
+            foreach (string topic in gPeers.Keys.Concat(fanout.Keys).Distinct()
+                .Where(topic => topicState.GetValueOrDefault(topic)?.IsSubscribed is true)
+                .ToArray())
             {
                 IGrouping<string, MessageWithId>? msgsInTopic = msgs.FirstOrDefault(mit => mit.Key == topic);
                 if (msgsInTopic is not null)
@@ -430,9 +432,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     ihave.MessageIDs.AddRange(msgsInTopic.Select(m => ByteString.CopyFrom(m.Id.Bytes)));
 
                     // Only send gossip to peers above gossip threshold
+                    HashSet<PeerId>? topicMesh = mesh.GetValueOrDefault(topic);
+                    HashSet<PeerId>? topicFanout = fanout.GetValueOrDefault(topic);
                     var eligiblePeers = gPeers[topic]
-                        .Where(p => !mesh[topic].Contains(p)
-                            && !fanout[topic].Contains(p)
+                        .Where(p => !(topicMesh?.Contains(p) ?? false)
+                            && !(topicFanout?.Contains(p) ?? false)
                             && GetPeerScore(p) >= _settings.GossipThreshold);
 
                     // Adaptive gossip: send to gossip_factor of eligible peers (min D_lazy)
@@ -507,7 +511,14 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 reconnections.Add(new Reconnection([addr], _settings.ReconnectionAttempts));
             });
 
-            string[] topics = topicState.Keys.ToArray();
+            string[] topics;
+            lock (this)
+            {
+                topics = topicState
+                    .Where(pair => pair.Value.IsSubscribed)
+                    .Select(pair => pair.Key)
+                    .ToArray();
+            }
 
             if (topics.Any())
             {

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
@@ -19,13 +19,16 @@ internal class Topic : ITopic
 
     private void OnRouterMessage(string topicName, PeerId peerId, byte[] message)
     {
-        if (!IsSubscribed || this.topicName != topicName)
+        lock (router)
         {
-            return;
-        }
+            if (!IsSubscribed || this.topicName != topicName)
+            {
+                return;
+            }
 
-        Action<PeerId, byte[]>? onMessage = OnMessage;
-        onMessage?.Invoke(peerId, message);
+            Action<PeerId, byte[]>? onMessage = OnMessage;
+            onMessage?.Invoke(peerId, message);
+        }
     }
 
     public DateTime LastPublished { get; set; }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
@@ -19,7 +19,7 @@ internal class Topic : ITopic
 
     private void OnRouterMessage(string topicName, PeerId peerId, byte[] message)
     {
-        if (this.topicName != topicName)
+        if (!IsSubscribed || this.topicName != topicName)
         {
             return;
         }
@@ -41,7 +41,7 @@ internal class Topic : ITopic
 
     public void Unsubscribe()
     {
-        if (!IsSubscribed) router.Unsubscribe(topicName);
+        if (IsSubscribed) router.Unsubscribe(topicName);
     }
 
     public void Subscribe()


### PR DESCRIPTION
## Summary
- make public topic unsubscribe transition subscription state correctly
- stop callbacks after a topic is unsubscribed
- preserve remote topic membership across local unsubscribe and resubscribe
- clear only local mesh and fanout state when a subscription ends
- notify every connected peer about an unsubscribe and omit inactive topics from reconnect and gossip messages

## Pipeline repair
This branch also includes the shared SIPSorcery security dependency update required for CI restore. It aligns the WebRTC certificate integration and is tracked independently in #208.

## Validation
- Added topic lifecycle coverage.