### PR TITLE
Harden strict pubsub no-sign validation

### DIFF
--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/StrictNoSignTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/StrictNoSignTests.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Google.Protobuf;
+using Nethermind.Libp2p.Protocols.Pubsub;
+using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
+
+[TestFixture]
+public class StrictNoSignTests
+{
+    [Test]
+    public void StrictNoSign_AcceptsMessagesWithoutAuthorshipFields()
+    {
+        Message message = new()
+        {
+            Topic = "no-sign",
+            Data = ByteString.CopyFrom([1, 2, 3]),
+        };
+
+        Assert.That(message.VerifySignature(PubsubSettings.SignaturePolicy.StrictNoSign), Is.True);
+    }
+
+    [Test]
+    public void StrictNoSign_RejectsExplicitlyPresentAuthorshipFields()
+    {
+        Message[] messages =
+        [
+            new Message { Signature = ByteString.Empty },
+            new Message { From = ByteString.Empty },
+            new Message { Seqno = ByteString.Empty },
+            new Message { Key = ByteString.Empty },
+        ];
+
+        Assert.Multiple(() =>
+        {
+            foreach (Message message in messages)
+            {
+                Assert.That(message.VerifySignature(PubsubSettings.SignaturePolicy.StrictNoSign), Is.False);
+            }
+        });
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/StrictNoSignTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/StrictNoSignTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using Google.Protobuf;
+using Nethermind.Libp2p.Core.Discovery;
 using Nethermind.Libp2p.Protocols.Pubsub;
 using Nethermind.Libp2p.Protocols.Pubsub.Dto;
 
@@ -27,10 +28,10 @@ public class StrictNoSignTests
     {
         Message[] messages =
         [
-            new Message { Signature = ByteString.Empty },
-            new Message { From = ByteString.Empty },
-            new Message { Seqno = ByteString.Empty },
-            new Message { Key = ByteString.Empty },
+            new Message { Topic = "no-sign", Signature = ByteString.Empty },
+            new Message { Topic = "no-sign", From = ByteString.Empty },
+            new Message { Topic = "no-sign", Seqno = ByteString.Empty },
+            new Message { Topic = "no-sign", Key = ByteString.Empty },
         ];
 
         Assert.Multiple(() =>
@@ -40,5 +41,48 @@ public class StrictNoSignTests
                 Assert.That(message.VerifySignature(PubsubSettings.SignaturePolicy.StrictNoSign), Is.False);
             }
         });
+    }
+
+    [Test]
+    public void StrictNoSign_RequiresACustomMessageId()
+    {
+        PubsubSettings settings = new()
+        {
+            DefaultSignaturePolicy = PubsubSettings.SignaturePolicy.StrictNoSign,
+        };
+
+        InvalidOperationException? exception = Assert.Throws<InvalidOperationException>(() => new PubsubRouter(new PeerStore(), settings));
+
+        Assert.That(exception!.Message, Does.Contain("GetMessageId"));
+    }
+
+    [Test]
+    public void StrictNoSign_DeliversDistinctMessagesWithACustomMessageId()
+    {
+        PubsubSettings settings = new()
+        {
+            DefaultSignaturePolicy = PubsubSettings.SignaturePolicy.StrictNoSign,
+            GetMessageId = message => new(message.Data.ToByteArray()),
+        };
+        using PubsubRouter router = new(new PeerStore(), settings);
+        ITopic topic = router.GetTopic("no-sign");
+        int deliveries = 0;
+        topic.OnMessage += (_, _) => deliveries++;
+
+        router.OnRpc(TestPeers.PeerId(1), CreateUnsignedMessage("first"));
+        router.OnRpc(TestPeers.PeerId(1), CreateUnsignedMessage("second"));
+
+        Assert.That(deliveries, Is.EqualTo(2));
+    }
+
+    private static Rpc CreateUnsignedMessage(string payload)
+    {
+        Rpc rpc = new();
+        rpc.Publish.Add(new Message
+        {
+            Topic = "no-sign",
+            Data = ByteString.CopyFromUtf8(payload),
+        });
+        return rpc;
     }
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -171,6 +171,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
         _peerStore = store;
         _settings = settings ?? PubsubSettings.Default;
+        if (_settings.DefaultSignaturePolicy is PubsubSettings.SignaturePolicy.StrictNoSign && _settings.GetMessageId == PubsubSettings.ConcatFromAndSeqno)
+        {
+            throw new InvalidOperationException("StrictNoSign requires a custom GetMessageId function.");
+        }
+
         _messageCache = new(_settings.MessageCacheTtl);
         _limboMessageCache = new(_settings.MessageCacheTtl);
         _idontwantMessages = new(_settings.MessageCacheTtl);

--- a/src/libp2p/Libp2p.Protocols.Pubsub/RpcExtensions.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/RpcExtensions.cs
@@ -49,7 +49,7 @@ internal static class RpcExtensions
     {
         if (signaturePolicy is PubsubSettings.SignaturePolicy.StrictNoSign)
         {
-            return message.Signature.IsEmpty;
+            return !message.HasSignature && !message.HasFrom && !message.HasSeqno && !message.HasKey;
         }
 
         PublicKey? pubKey = PeerId.ExtractPublicKey(message.From.ToArray());


### PR DESCRIPTION
## Summary
- reject all explicitly present authorship fields in strict no-sign mode
- distinguish absent protobuf fields from explicitly encoded empty fields
- require an application-defined message ID when strict no-sign mode is selected
- add coverage for accepted unsigned messages, rejected metadata, and distinct custom IDs

## Pipeline repair
This branch also includes the shared SIPSorcery security dependency update required for CI restore. It aligns the WebRTC certificate integration and is tracked independently in #208.

## Validation
- Added strict no-sign policy coverage.