### PR TITLE
Add Gossipsub v1.3 extensions control support

### DIFF
--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubV13ProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubV13ProtocolTests.cs
@@ -34,7 +34,7 @@ public class GossipsubV13ProtocolTests
             },
             Partial = new PartialMessagesExtension
             {
-                TopicID = "topic",
+                TopicID = ByteString.CopyFromUtf8("topic"),
                 GroupID = ByteString.CopyFrom([1, 2]),
                 PartialMessage = ByteString.CopyFrom([3]),
                 PartsMetadata = ByteString.CopyFrom([4]),
@@ -53,11 +53,29 @@ public class GossipsubV13ProtocolTests
         Assert.Multiple(() =>
         {
             Assert.That(decoded.Control.Extensions.PartialMessages, Is.True);
-            Assert.That(decoded.Partial.TopicID, Is.EqualTo("topic"));
+            Assert.That(decoded.Partial.TopicID.ToStringUtf8(), Is.EqualTo("topic"));
             Assert.That(decoded.Partial.GroupID.ToByteArray(), Is.EqualTo(new byte[] { 1, 2 }));
             Assert.That(decoded.Subscriptions.Single().RequestsPartial, Is.True);
             Assert.That(decoded.Subscriptions.Single().SupportsSendingPartial, Is.True);
         });
+    }
+
+    [Test]
+    public void ExtensionRegistry_PreservesOpaquePartialMessageTopicBytes()
+    {
+        Rpc rpc = new()
+        {
+            Partial = new PartialMessagesExtension
+            {
+                TopicID = ByteString.CopyFrom([0xff, 0x00, 0x80]),
+                GroupID = ByteString.CopyFrom([1]),
+                PartialMessage = ByteString.CopyFrom([2]),
+            },
+        };
+
+        Rpc decoded = Rpc.Parser.ParseFrom(rpc.ToByteArray());
+
+        Assert.That(decoded.Partial.TopicID.ToByteArray(), Is.EqualTo(new byte[] { 0xff, 0x00, 0x80 }));
     }
 
     [Test]

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubV13ProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubV13ProtocolTests.cs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Google.Protobuf;
+using Multiformats.Address;
+using Nethermind.Libp2p.Core.Discovery;
+using Nethermind.Libp2p.Protocols;
+using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+using System.Collections.ObjectModel;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
+
+[TestFixture]
+public class GossipsubV13ProtocolTests
+{
+    [Test]
+    public void Protocol_UsesTheV13ProtocolId()
+    {
+        PubsubRouter router = new(new PeerStore());
+
+        GossipsubProtocolV13 protocol = new(router);
+
+        Assert.That(protocol.Id, Is.EqualTo(PubsubRouter.GossipsubProtocolVersionV13));
+    }
+
+    [Test]
+    public void ExtensionRegistryMessages_RoundTrip()
+    {
+        Rpc rpc = new()
+        {
+            Control = new ControlMessage
+            {
+                Extensions = new ControlExtensions { PartialMessages = true },
+            },
+            Partial = new PartialMessagesExtension
+            {
+                TopicID = "topic",
+                GroupID = ByteString.CopyFrom([1, 2]),
+                PartialMessage = ByteString.CopyFrom([3]),
+                PartsMetadata = ByteString.CopyFrom([4]),
+            },
+        };
+        rpc.Subscriptions.Add(new Rpc.Types.SubOpts
+        {
+            Subscribe = true,
+            Topicid = "topic",
+            RequestsPartial = true,
+            SupportsSendingPartial = true,
+        });
+
+        Rpc decoded = Rpc.Parser.ParseFrom(rpc.ToByteArray());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(decoded.Control.Extensions.PartialMessages, Is.True);
+            Assert.That(decoded.Partial.TopicID, Is.EqualTo("topic"));
+            Assert.That(decoded.Partial.GroupID.ToByteArray(), Is.EqualTo(new byte[] { 1, 2 }));
+            Assert.That(decoded.Subscriptions.Single().RequestsPartial, Is.True);
+            Assert.That(decoded.Subscriptions.Single().SupportsSendingPartial, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task Router_PrefersV13WhenTheRemotePeerAdvertisesIt()
+    {
+        PeerStore peerStore = new();
+        PubsubRouter router = new(peerStore);
+        Multiaddress remoteAddress = TestPeers.Multiaddr(1);
+        PeerId remotePeerId = remoteAddress.GetPeerId()!;
+        peerStore.GetPeerInfo(remotePeerId).SupportedProtocols = [
+            PubsubRouter.GossipsubProtocolVersionV12,
+            PubsubRouter.GossipsubProtocolVersionV13,
+        ];
+
+        TaskCompletionSource selectedProtocol = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        ISession session = Substitute.For<ISession>();
+        session.RemoteAddress.Returns(remoteAddress);
+        session.DialAsync<GossipsubProtocolV13>(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            selectedProtocol.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        ILocalPeer localPeer = Substitute.For<ILocalPeer>();
+        localPeer.Identity.Returns(TestPeers.Identity(2));
+        localPeer.ListenAddresses.Returns(new ObservableCollection<Multiaddress>());
+        localPeer.DialAsync(Arg.Any<Multiaddress[]>(), Arg.Any<CancellationToken>()).Returns(session);
+
+        using CancellationTokenSource cancellation = new();
+        await router.StartAsync(localPeer, cancellation.Token);
+        peerStore.Discover([remoteAddress]);
+
+        await selectedProtocol.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        _ = session.Received(1).DialAsync<GossipsubProtocolV13>(Arg.Any<CancellationToken>());
+
+        cancellation.Cancel();
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.cs
@@ -24,36 +24,44 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
     static RpcReflection() {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
-            "CglScGMucHJvdG8ilgEKA1JwYxIjCg1zdWJzY3JpcHRpb25zGAEgAygLMgwu",
+            "CglScGMucHJvdG8i+wEKA1JwYxIjCg1zdWJzY3JpcHRpb25zGAEgAygLMgwu",
             "UnBjLlN1Yk9wdHMSGQoHcHVibGlzaBgCIAMoCzIILk1lc3NhZ2USIAoHY29u",
-            "dHJvbBgDIAEoCzIPLkNvbnRyb2xNZXNzYWdlGi0KB1N1Yk9wdHMSEQoJc3Vi",
-            "c2NyaWJlGAEgASgIEg8KB3RvcGljaWQYAiABKAkiYwoHTWVzc2FnZRIMCgRm",
-            "cm9tGAEgASgMEgwKBGRhdGEYAiABKAwSDQoFc2Vxbm8YAyABKAwSDQoFdG9w",
-            "aWMYBCACKAkSEQoJc2lnbmF0dXJlGAUgASgMEgsKA2tleRgGIAEoDCKuAQoO",
-            "Q29udHJvbE1lc3NhZ2USHAoFaWhhdmUYASADKAsyDS5Db250cm9sSUhhdmUS",
-            "HAoFaXdhbnQYAiADKAsyDS5Db250cm9sSVdhbnQSHAoFZ3JhZnQYAyADKAsy",
-            "DS5Db250cm9sR3JhZnQSHAoFcHJ1bmUYBCADKAsyDS5Db250cm9sUHJ1bmUS",
-            "JAoJaWRvbnR3YW50GAUgAygLMhEuQ29udHJvbElEb250V2FudCIzCgxDb250",
-            "cm9sSUhhdmUSDwoHdG9waWNJRBgBIAEoCRISCgptZXNzYWdlSURzGAIgAygM",
-            "IiIKDENvbnRyb2xJV2FudBISCgptZXNzYWdlSURzGAEgAygMIh8KDENvbnRy",
-            "b2xHcmFmdBIPCgd0b3BpY0lEGAEgASgJIkoKDENvbnRyb2xQcnVuZRIPCgd0",
-            "b3BpY0lEGAEgASgJEhgKBXBlZXJzGAIgAygLMgkuUGVlckluZm8SDwoHYmFj",
-            "a29mZhgDIAEoBCI0CghQZWVySW5mbxIOCgZwZWVySUQYASABKAwSGAoQc2ln",
-            "bmVkUGVlclJlY29yZBgCIAEoDCImChBDb250cm9sSURvbnRXYW50EhIKCm1l",
-            "c3NhZ2VJRHMYASADKAxCKaoCJk5ldGhlcm1pbmQuTGlicDJwLlByb3RvY29s",
-            "cy5QdWJzdWIuRHRv"));
+            "dHJvbBgDIAEoCzIPLkNvbnRyb2xNZXNzYWdlEioKB3BhcnRpYWwYCiABKAsy",
+            "GS5QYXJ0aWFsTWVzc2FnZXNFeHRlbnNpb24aZgoHU3ViT3B0cxIRCglzdWJz",
+            "Y3JpYmUYASABKAgSDwoHdG9waWNpZBgCIAEoCRIXCg9yZXF1ZXN0c1BhcnRp",
+            "YWwYAyABKAgSHgoWc3VwcG9ydHNTZW5kaW5nUGFydGlhbBgEIAEoCCJjCgdN",
+            "ZXNzYWdlEgwKBGZyb20YASABKAwSDAoEZGF0YRgCIAEoDBINCgVzZXFubxgD",
+            "IAEoDBINCgV0b3BpYxgEIAIoCRIRCglzaWduYXR1cmUYBSABKAwSCwoDa2V5",
+            "GAYgASgMItYBCg5Db250cm9sTWVzc2FnZRIcCgVpaGF2ZRgBIAMoCzINLkNv",
+            "bnRyb2xJSGF2ZRIcCgVpd2FudBgCIAMoCzINLkNvbnRyb2xJV2FudBIcCgVn",
+            "cmFmdBgDIAMoCzINLkNvbnRyb2xHcmFmdBIcCgVwcnVuZRgEIAMoCzINLkNv",
+            "bnRyb2xQcnVuZRIkCglpZG9udHdhbnQYBSADKAsyES5Db250cm9sSURvbnRX",
+            "YW50EiYKCmV4dGVuc2lvbnMYBiABKAsyEi5Db250cm9sRXh0ZW5zaW9ucyIz",
+            "CgxDb250cm9sSUhhdmUSDwoHdG9waWNJRBgBIAEoCRISCgptZXNzYWdlSURz",
+            "GAIgAygMIiIKDENvbnRyb2xJV2FudBISCgptZXNzYWdlSURzGAEgAygMIh8K",
+            "DENvbnRyb2xHcmFmdBIPCgd0b3BpY0lEGAEgASgJIkoKDENvbnRyb2xQcnVu",
+            "ZRIPCgd0b3BpY0lEGAEgASgJEhgKBXBlZXJzGAIgAygLMgkuUGVlckluZm8S",
+            "DwoHYmFja29mZhgDIAEoBCI0CghQZWVySW5mbxIOCgZwZWVySUQYASABKAwS",
+            "GAoQc2lnbmVkUGVlclJlY29yZBgCIAEoDCImChBDb250cm9sSURvbnRXYW50",
+            "EhIKCm1lc3NhZ2VJRHMYASADKAwiLAoRQ29udHJvbEV4dGVuc2lvbnMSFwoP",
+            "cGFydGlhbE1lc3NhZ2VzGAogASgIImsKGFBhcnRpYWxNZXNzYWdlc0V4dGVu",
+            "c2lvbhIPCgd0b3BpY0lEGAEgASgJEg8KB2dyb3VwSUQYAiABKAwSFgoOcGFy",
+            "dGlhbE1lc3NhZ2UYAyABKAwSFQoNcGFydHNNZXRhZGF0YRgEIAEoDEIpqgIm",
+            "TmV0aGVybWluZC5MaWJwMnAuUHJvdG9jb2xzLlB1YnN1Yi5EdG8="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Rpc), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Rpc.Parser, new[]{ "Subscriptions", "Publish", "Control" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Rpc.Types.SubOpts), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Rpc.Types.SubOpts.Parser, new[]{ "Subscribe", "Topicid" }, null, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Rpc), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Rpc.Parser, new[]{ "Subscriptions", "Publish", "Control", "Partial" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Rpc.Types.SubOpts), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Rpc.Types.SubOpts.Parser, new[]{ "Subscribe", "Topicid", "RequestsPartial", "SupportsSendingPartial" }, null, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Message), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.Message.Parser, new[]{ "From", "Data", "Seqno", "Topic", "Signature", "Key" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlMessage), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlMessage.Parser, new[]{ "Ihave", "Iwant", "Graft", "Prune", "Idontwant" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlMessage), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlMessage.Parser, new[]{ "Ihave", "Iwant", "Graft", "Prune", "Idontwant", "Extensions" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlIHave), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlIHave.Parser, new[]{ "TopicID", "MessageIDs" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlIWant), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlIWant.Parser, new[]{ "MessageIDs" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlGraft), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlGraft.Parser, new[]{ "TopicID" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlPrune), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlPrune.Parser, new[]{ "TopicID", "Peers", "Backoff" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.PeerInfo), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.PeerInfo.Parser, new[]{ "PeerID", "SignedPeerRecord" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlIDontWant), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlIDontWant.Parser, new[]{ "MessageIDs" }, null, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlIDontWant), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlIDontWant.Parser, new[]{ "MessageIDs" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlExtensions), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlExtensions.Parser, new[]{ "PartialMessages" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Nethermind.Libp2p.Protocols.Pubsub.Dto.PartialMessagesExtension), global::Nethermind.Libp2p.Protocols.Pubsub.Dto.PartialMessagesExtension.Parser, new[]{ "TopicID", "GroupID", "PartialMessage", "PartsMetadata" }, null, null, null, null)
           }));
     }
     #endregion
@@ -98,6 +106,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       subscriptions_ = other.subscriptions_.Clone();
       publish_ = other.publish_.Clone();
       control_ = other.control_ != null ? other.control_.Clone() : null;
+      partial_ = other.partial_ != null ? other.partial_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -141,6 +150,21 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       }
     }
 
+    /// <summary>Field number for the "partial" field.</summary>
+    public const int PartialFieldNumber = 10;
+    private global::Nethermind.Libp2p.Protocols.Pubsub.Dto.PartialMessagesExtension partial_;
+    /// <summary>
+    /// Canonical Gossipsub v1.3 extensions are registered here.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Nethermind.Libp2p.Protocols.Pubsub.Dto.PartialMessagesExtension Partial {
+      get { return partial_; }
+      set {
+        partial_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -159,6 +183,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       if(!subscriptions_.Equals(other.subscriptions_)) return false;
       if(!publish_.Equals(other.publish_)) return false;
       if (!object.Equals(Control, other.Control)) return false;
+      if (!object.Equals(Partial, other.Partial)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -169,6 +194,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       hash ^= subscriptions_.GetHashCode();
       hash ^= publish_.GetHashCode();
       if (control_ != null) hash ^= Control.GetHashCode();
+      if (partial_ != null) hash ^= Partial.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -193,6 +219,10 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
         output.WriteRawTag(26);
         output.WriteMessage(Control);
       }
+      if (partial_ != null) {
+        output.WriteRawTag(82);
+        output.WriteMessage(Partial);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -209,6 +239,10 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
         output.WriteRawTag(26);
         output.WriteMessage(Control);
       }
+      if (partial_ != null) {
+        output.WriteRawTag(82);
+        output.WriteMessage(Partial);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -223,6 +257,9 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       size += publish_.CalculateSize(_repeated_publish_codec);
       if (control_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Control);
+      }
+      if (partial_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Partial);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -243,6 +280,12 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
           Control = new global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlMessage();
         }
         Control.MergeFrom(other.Control);
+      }
+      if (other.partial_ != null) {
+        if (partial_ == null) {
+          Partial = new global::Nethermind.Libp2p.Protocols.Pubsub.Dto.PartialMessagesExtension();
+        }
+        Partial.MergeFrom(other.Partial);
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -278,6 +321,13 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
             input.ReadMessage(Control);
             break;
           }
+          case 82: {
+            if (partial_ == null) {
+              Partial = new global::Nethermind.Libp2p.Protocols.Pubsub.Dto.PartialMessagesExtension();
+            }
+            input.ReadMessage(Partial);
+            break;
+          }
         }
       }
     #endif
@@ -310,6 +360,13 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
               Control = new global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlMessage();
             }
             input.ReadMessage(Control);
+            break;
+          }
+          case 82: {
+            if (partial_ == null) {
+              Partial = new global::Nethermind.Libp2p.Protocols.Pubsub.Dto.PartialMessagesExtension();
+            }
+            input.ReadMessage(Partial);
             break;
           }
         }
@@ -361,6 +418,8 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
           _hasBits0 = other._hasBits0;
           subscribe_ = other.subscribe_;
           topicid_ = other.topicid_;
+          requestsPartial_ = other.requestsPartial_;
+          supportsSendingPartial_ = other.supportsSendingPartial_;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -423,6 +482,63 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
           topicid_ = null;
         }
 
+        /// <summary>Field number for the "requestsPartial" field.</summary>
+        public const int RequestsPartialFieldNumber = 3;
+        private readonly static bool RequestsPartialDefaultValue = false;
+
+        private bool requestsPartial_;
+        /// <summary>
+        /// Used with the Gossipsub v1.3 Partial Messages extension.
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool RequestsPartial {
+          get { if ((_hasBits0 & 2) != 0) { return requestsPartial_; } else { return RequestsPartialDefaultValue; } }
+          set {
+            _hasBits0 |= 2;
+            requestsPartial_ = value;
+          }
+        }
+        /// <summary>Gets whether the "requestsPartial" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasRequestsPartial {
+          get { return (_hasBits0 & 2) != 0; }
+        }
+        /// <summary>Clears the value of the "requestsPartial" field</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearRequestsPartial() {
+          _hasBits0 &= ~2;
+        }
+
+        /// <summary>Field number for the "supportsSendingPartial" field.</summary>
+        public const int SupportsSendingPartialFieldNumber = 4;
+        private readonly static bool SupportsSendingPartialDefaultValue = false;
+
+        private bool supportsSendingPartial_;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool SupportsSendingPartial {
+          get { if ((_hasBits0 & 4) != 0) { return supportsSendingPartial_; } else { return SupportsSendingPartialDefaultValue; } }
+          set {
+            _hasBits0 |= 4;
+            supportsSendingPartial_ = value;
+          }
+        }
+        /// <summary>Gets whether the "supportsSendingPartial" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasSupportsSendingPartial {
+          get { return (_hasBits0 & 4) != 0; }
+        }
+        /// <summary>Clears the value of the "supportsSendingPartial" field</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearSupportsSendingPartial() {
+          _hasBits0 &= ~4;
+        }
+
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
@@ -440,6 +556,8 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
           }
           if (Subscribe != other.Subscribe) return false;
           if (Topicid != other.Topicid) return false;
+          if (RequestsPartial != other.RequestsPartial) return false;
+          if (SupportsSendingPartial != other.SupportsSendingPartial) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
 
@@ -449,6 +567,8 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
           int hash = 1;
           if (HasSubscribe) hash ^= Subscribe.GetHashCode();
           if (HasTopicid) hash ^= Topicid.GetHashCode();
+          if (HasRequestsPartial) hash ^= RequestsPartial.GetHashCode();
+          if (HasSupportsSendingPartial) hash ^= SupportsSendingPartial.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -475,6 +595,14 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
             output.WriteRawTag(18);
             output.WriteString(Topicid);
           }
+          if (HasRequestsPartial) {
+            output.WriteRawTag(24);
+            output.WriteBool(RequestsPartial);
+          }
+          if (HasSupportsSendingPartial) {
+            output.WriteRawTag(32);
+            output.WriteBool(SupportsSendingPartial);
+          }
           if (_unknownFields != null) {
             _unknownFields.WriteTo(output);
           }
@@ -493,6 +621,14 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
             output.WriteRawTag(18);
             output.WriteString(Topicid);
           }
+          if (HasRequestsPartial) {
+            output.WriteRawTag(24);
+            output.WriteBool(RequestsPartial);
+          }
+          if (HasSupportsSendingPartial) {
+            output.WriteRawTag(32);
+            output.WriteBool(SupportsSendingPartial);
+          }
           if (_unknownFields != null) {
             _unknownFields.WriteTo(ref output);
           }
@@ -508,6 +644,12 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
           }
           if (HasTopicid) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Topicid);
+          }
+          if (HasRequestsPartial) {
+            size += 1 + 1;
+          }
+          if (HasSupportsSendingPartial) {
+            size += 1 + 1;
           }
           if (_unknownFields != null) {
             size += _unknownFields.CalculateSize();
@@ -526,6 +668,12 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
           }
           if (other.HasTopicid) {
             Topicid = other.Topicid;
+          }
+          if (other.HasRequestsPartial) {
+            RequestsPartial = other.RequestsPartial;
+          }
+          if (other.HasSupportsSendingPartial) {
+            SupportsSendingPartial = other.SupportsSendingPartial;
           }
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
@@ -554,6 +702,14 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
                 Topicid = input.ReadString();
                 break;
               }
+              case 24: {
+                RequestsPartial = input.ReadBool();
+                break;
+              }
+              case 32: {
+                SupportsSendingPartial = input.ReadBool();
+                break;
+              }
             }
           }
         #endif
@@ -579,6 +735,14 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
               }
               case 18: {
                 Topicid = input.ReadString();
+                break;
+              }
+              case 24: {
+                RequestsPartial = input.ReadBool();
+                break;
+              }
+              case 32: {
+                SupportsSendingPartial = input.ReadBool();
                 break;
               }
             }
@@ -1100,6 +1264,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       graft_ = other.graft_.Clone();
       prune_ = other.prune_.Clone();
       idontwant_ = other.idontwant_.Clone();
+      extensions_ = other.extensions_ != null ? other.extensions_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -1164,6 +1329,18 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       get { return idontwant_; }
     }
 
+    /// <summary>Field number for the "extensions" field.</summary>
+    public const int ExtensionsFieldNumber = 6;
+    private global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlExtensions extensions_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlExtensions Extensions {
+      get { return extensions_; }
+      set {
+        extensions_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -1184,6 +1361,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       if(!graft_.Equals(other.graft_)) return false;
       if(!prune_.Equals(other.prune_)) return false;
       if(!idontwant_.Equals(other.idontwant_)) return false;
+      if (!object.Equals(Extensions, other.Extensions)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -1196,6 +1374,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       hash ^= graft_.GetHashCode();
       hash ^= prune_.GetHashCode();
       hash ^= idontwant_.GetHashCode();
+      if (extensions_ != null) hash ^= Extensions.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -1219,6 +1398,10 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       graft_.WriteTo(output, _repeated_graft_codec);
       prune_.WriteTo(output, _repeated_prune_codec);
       idontwant_.WriteTo(output, _repeated_idontwant_codec);
+      if (extensions_ != null) {
+        output.WriteRawTag(50);
+        output.WriteMessage(Extensions);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1234,6 +1417,10 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       graft_.WriteTo(ref output, _repeated_graft_codec);
       prune_.WriteTo(ref output, _repeated_prune_codec);
       idontwant_.WriteTo(ref output, _repeated_idontwant_codec);
+      if (extensions_ != null) {
+        output.WriteRawTag(50);
+        output.WriteMessage(Extensions);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1249,6 +1436,9 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       size += graft_.CalculateSize(_repeated_graft_codec);
       size += prune_.CalculateSize(_repeated_prune_codec);
       size += idontwant_.CalculateSize(_repeated_idontwant_codec);
+      if (extensions_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Extensions);
+      }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -1266,6 +1456,12 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
       graft_.Add(other.graft_);
       prune_.Add(other.prune_);
       idontwant_.Add(other.idontwant_);
+      if (other.extensions_ != null) {
+        if (extensions_ == null) {
+          Extensions = new global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlExtensions();
+        }
+        Extensions.MergeFrom(other.Extensions);
+      }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -1305,6 +1501,13 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
             idontwant_.AddEntriesFrom(input, _repeated_idontwant_codec);
             break;
           }
+          case 50: {
+            if (extensions_ == null) {
+              Extensions = new global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlExtensions();
+            }
+            input.ReadMessage(Extensions);
+            break;
+          }
         }
       }
     #endif
@@ -1342,6 +1545,13 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
           }
           case 42: {
             idontwant_.AddEntriesFrom(ref input, _repeated_idontwant_codec);
+            break;
+          }
+          case 50: {
+            if (extensions_ == null) {
+              Extensions = new global::Nethermind.Libp2p.Protocols.Pubsub.Dto.ControlExtensions();
+            }
+            input.ReadMessage(Extensions);
             break;
           }
         }
@@ -2727,6 +2937,595 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
             break;
           case 10: {
             messageIDs_.AddEntriesFrom(ref input, _repeated_messageIDs_codec);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  /// <summary>
+  /// Gossipsub v1.3 extension capabilities. Unknown fields are intentionally
+  /// ignored so future extensions remain wire compatible.
+  /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class ControlExtensions : pb::IMessage<ControlExtensions>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<ControlExtensions> _parser = new pb::MessageParser<ControlExtensions>(() => new ControlExtensions());
+    private pb::UnknownFieldSet _unknownFields;
+    private int _hasBits0;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<ControlExtensions> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Nethermind.Libp2p.Protocols.Pubsub.Dto.RpcReflection.Descriptor.MessageTypes[9]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ControlExtensions() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ControlExtensions(ControlExtensions other) : this() {
+      _hasBits0 = other._hasBits0;
+      partialMessages_ = other.partialMessages_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ControlExtensions Clone() {
+      return new ControlExtensions(this);
+    }
+
+    /// <summary>Field number for the "partialMessages" field.</summary>
+    public const int PartialMessagesFieldNumber = 10;
+    private readonly static bool PartialMessagesDefaultValue = false;
+
+    private bool partialMessages_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool PartialMessages {
+      get { if ((_hasBits0 & 1) != 0) { return partialMessages_; } else { return PartialMessagesDefaultValue; } }
+      set {
+        _hasBits0 |= 1;
+        partialMessages_ = value;
+      }
+    }
+    /// <summary>Gets whether the "partialMessages" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPartialMessages {
+      get { return (_hasBits0 & 1) != 0; }
+    }
+    /// <summary>Clears the value of the "partialMessages" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPartialMessages() {
+      _hasBits0 &= ~1;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as ControlExtensions);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(ControlExtensions other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (PartialMessages != other.PartialMessages) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (HasPartialMessages) hash ^= PartialMessages.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (HasPartialMessages) {
+        output.WriteRawTag(80);
+        output.WriteBool(PartialMessages);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (HasPartialMessages) {
+        output.WriteRawTag(80);
+        output.WriteBool(PartialMessages);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (HasPartialMessages) {
+        size += 1 + 1;
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(ControlExtensions other) {
+      if (other == null) {
+        return;
+      }
+      if (other.HasPartialMessages) {
+        PartialMessages = other.PartialMessages;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 80: {
+            PartialMessages = input.ReadBool();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 80: {
+            PartialMessages = input.ReadBool();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  /// <summary>
+  /// The Partial Messages extension uses an application-defined encoding for
+  /// message parts and metadata. topicID is a string to match the Go reference;
+  /// both it and the registry's bytes form use the same protobuf wire type.
+  /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class PartialMessagesExtension : pb::IMessage<PartialMessagesExtension>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<PartialMessagesExtension> _parser = new pb::MessageParser<PartialMessagesExtension>(() => new PartialMessagesExtension());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<PartialMessagesExtension> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Nethermind.Libp2p.Protocols.Pubsub.Dto.RpcReflection.Descriptor.MessageTypes[10]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PartialMessagesExtension() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PartialMessagesExtension(PartialMessagesExtension other) : this() {
+      topicID_ = other.topicID_;
+      groupID_ = other.groupID_;
+      partialMessage_ = other.partialMessage_;
+      partsMetadata_ = other.partsMetadata_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PartialMessagesExtension Clone() {
+      return new PartialMessagesExtension(this);
+    }
+
+    /// <summary>Field number for the "topicID" field.</summary>
+    public const int TopicIDFieldNumber = 1;
+    private readonly static string TopicIDDefaultValue = "";
+
+    private string topicID_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string TopicID {
+      get { return topicID_ ?? TopicIDDefaultValue; }
+      set {
+        topicID_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+    /// <summary>Gets whether the "topicID" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasTopicID {
+      get { return topicID_ != null; }
+    }
+    /// <summary>Clears the value of the "topicID" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearTopicID() {
+      topicID_ = null;
+    }
+
+    /// <summary>Field number for the "groupID" field.</summary>
+    public const int GroupIDFieldNumber = 2;
+    private readonly static pb::ByteString GroupIDDefaultValue = pb::ByteString.Empty;
+
+    private pb::ByteString groupID_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString GroupID {
+      get { return groupID_ ?? GroupIDDefaultValue; }
+      set {
+        groupID_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+    /// <summary>Gets whether the "groupID" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasGroupID {
+      get { return groupID_ != null; }
+    }
+    /// <summary>Clears the value of the "groupID" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearGroupID() {
+      groupID_ = null;
+    }
+
+    /// <summary>Field number for the "partialMessage" field.</summary>
+    public const int PartialMessageFieldNumber = 3;
+    private readonly static pb::ByteString PartialMessageDefaultValue = pb::ByteString.Empty;
+
+    private pb::ByteString partialMessage_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString PartialMessage {
+      get { return partialMessage_ ?? PartialMessageDefaultValue; }
+      set {
+        partialMessage_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+    /// <summary>Gets whether the "partialMessage" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPartialMessage {
+      get { return partialMessage_ != null; }
+    }
+    /// <summary>Clears the value of the "partialMessage" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPartialMessage() {
+      partialMessage_ = null;
+    }
+
+    /// <summary>Field number for the "partsMetadata" field.</summary>
+    public const int PartsMetadataFieldNumber = 4;
+    private readonly static pb::ByteString PartsMetadataDefaultValue = pb::ByteString.Empty;
+
+    private pb::ByteString partsMetadata_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString PartsMetadata {
+      get { return partsMetadata_ ?? PartsMetadataDefaultValue; }
+      set {
+        partsMetadata_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+    /// <summary>Gets whether the "partsMetadata" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPartsMetadata {
+      get { return partsMetadata_ != null; }
+    }
+    /// <summary>Clears the value of the "partsMetadata" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPartsMetadata() {
+      partsMetadata_ = null;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as PartialMessagesExtension);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(PartialMessagesExtension other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (TopicID != other.TopicID) return false;
+      if (GroupID != other.GroupID) return false;
+      if (PartialMessage != other.PartialMessage) return false;
+      if (PartsMetadata != other.PartsMetadata) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (HasTopicID) hash ^= TopicID.GetHashCode();
+      if (HasGroupID) hash ^= GroupID.GetHashCode();
+      if (HasPartialMessage) hash ^= PartialMessage.GetHashCode();
+      if (HasPartsMetadata) hash ^= PartsMetadata.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (HasTopicID) {
+        output.WriteRawTag(10);
+        output.WriteString(TopicID);
+      }
+      if (HasGroupID) {
+        output.WriteRawTag(18);
+        output.WriteBytes(GroupID);
+      }
+      if (HasPartialMessage) {
+        output.WriteRawTag(26);
+        output.WriteBytes(PartialMessage);
+      }
+      if (HasPartsMetadata) {
+        output.WriteRawTag(34);
+        output.WriteBytes(PartsMetadata);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (HasTopicID) {
+        output.WriteRawTag(10);
+        output.WriteString(TopicID);
+      }
+      if (HasGroupID) {
+        output.WriteRawTag(18);
+        output.WriteBytes(GroupID);
+      }
+      if (HasPartialMessage) {
+        output.WriteRawTag(26);
+        output.WriteBytes(PartialMessage);
+      }
+      if (HasPartsMetadata) {
+        output.WriteRawTag(34);
+        output.WriteBytes(PartsMetadata);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (HasTopicID) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(TopicID);
+      }
+      if (HasGroupID) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(GroupID);
+      }
+      if (HasPartialMessage) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(PartialMessage);
+      }
+      if (HasPartsMetadata) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(PartsMetadata);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(PartialMessagesExtension other) {
+      if (other == null) {
+        return;
+      }
+      if (other.HasTopicID) {
+        TopicID = other.TopicID;
+      }
+      if (other.HasGroupID) {
+        GroupID = other.GroupID;
+      }
+      if (other.HasPartialMessage) {
+        PartialMessage = other.PartialMessage;
+      }
+      if (other.HasPartsMetadata) {
+        PartsMetadata = other.PartsMetadata;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            TopicID = input.ReadString();
+            break;
+          }
+          case 18: {
+            GroupID = input.ReadBytes();
+            break;
+          }
+          case 26: {
+            PartialMessage = input.ReadBytes();
+            break;
+          }
+          case 34: {
+            PartsMetadata = input.ReadBytes();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            TopicID = input.ReadString();
+            break;
+          }
+          case 18: {
+            GroupID = input.ReadBytes();
+            break;
+          }
+          case 26: {
+            PartialMessage = input.ReadBytes();
+            break;
+          }
+          case 34: {
+            PartsMetadata = input.ReadBytes();
             break;
           }
         }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
             "GAoQc2lnbmVkUGVlclJlY29yZBgCIAEoDCImChBDb250cm9sSURvbnRXYW50",
             "EhIKCm1lc3NhZ2VJRHMYASADKAwiLAoRQ29udHJvbEV4dGVuc2lvbnMSFwoP",
             "cGFydGlhbE1lc3NhZ2VzGAogASgIImsKGFBhcnRpYWxNZXNzYWdlc0V4dGVu",
-            "c2lvbhIPCgd0b3BpY0lEGAEgASgJEg8KB2dyb3VwSUQYAiABKAwSFgoOcGFy",
+            "c2lvbhIPCgd0b3BpY0lEGAEgASgMEg8KB2dyb3VwSUQYAiABKAwSFgoOcGFy",
             "dGlhbE1lc3NhZ2UYAyABKAwSFQoNcGFydHNNZXRhZGF0YRgEIAEoDEIpqgIm",
             "TmV0aGVybWluZC5MaWJwMnAuUHJvdG9jb2xzLlB1YnN1Yi5EdG8="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
@@ -3166,9 +3166,8 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
   }
 
   /// <summary>
-  /// The Partial Messages extension uses an application-defined encoding for
-  /// message parts and metadata. topicID is a string to match the Go reference;
-  /// both it and the registry's bytes form use the same protobuf wire type.
+  /// The Partial Messages registry identifies topics as opaque bytes. Go's
+  /// current string declaration is wire compatible with this canonical form.
   /// </summary>
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PartialMessagesExtension : pb::IMessage<PartialMessagesExtension>
@@ -3220,12 +3219,12 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
 
     /// <summary>Field number for the "topicID" field.</summary>
     public const int TopicIDFieldNumber = 1;
-    private readonly static string TopicIDDefaultValue = "";
+    private readonly static pb::ByteString TopicIDDefaultValue = pb::ByteString.Empty;
 
-    private string topicID_;
+    private pb::ByteString topicID_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string TopicID {
+    public pb::ByteString TopicID {
       get { return topicID_ ?? TopicIDDefaultValue; }
       set {
         topicID_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
@@ -3372,7 +3371,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
     #else
       if (HasTopicID) {
         output.WriteRawTag(10);
-        output.WriteString(TopicID);
+        output.WriteBytes(TopicID);
       }
       if (HasGroupID) {
         output.WriteRawTag(18);
@@ -3398,7 +3397,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
       if (HasTopicID) {
         output.WriteRawTag(10);
-        output.WriteString(TopicID);
+        output.WriteBytes(TopicID);
       }
       if (HasGroupID) {
         output.WriteRawTag(18);
@@ -3423,7 +3422,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
     public int CalculateSize() {
       int size = 0;
       if (HasTopicID) {
-        size += 1 + pb::CodedOutputStream.ComputeStringSize(TopicID);
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(TopicID);
       }
       if (HasGroupID) {
         size += 1 + pb::CodedOutputStream.ComputeBytesSize(GroupID);
@@ -3478,7 +3477,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            TopicID = input.ReadString();
+            TopicID = input.ReadBytes();
             break;
           }
           case 18: {
@@ -3513,7 +3512,7 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
           case 10: {
-            TopicID = input.ReadString();
+            TopicID = input.ReadBytes();
             break;
           }
           case 18: {

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.proto
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.proto
@@ -7,9 +7,15 @@ message Rpc {
   repeated Message publish = 2;
   optional ControlMessage control = 3;
 
+  // Canonical Gossipsub v1.3 extensions are registered here.
+  optional PartialMessagesExtension partial = 10;
+
   message SubOpts {
     optional bool subscribe = 1;
     optional string topicid = 2;
+    // Used with the Gossipsub v1.3 Partial Messages extension.
+    optional bool requestsPartial = 3;
+    optional bool supportsSendingPartial = 4;
   }
 }
 
@@ -28,6 +34,7 @@ message ControlMessage {
   repeated ControlGraft graft = 3; 
   repeated ControlPrune prune = 4;
   repeated ControlIDontWant idontwant = 5;
+  optional ControlExtensions extensions = 6;
 }
 
 message ControlIHave {
@@ -49,11 +56,27 @@ message ControlPrune {
 	optional uint64 backoff = 3; // gossipsub v1.1 backoff time (in seconds)
 }
 
+message PeerInfo {
+	optional bytes peerID = 1;
+	optional bytes signedPeerRecord = 2;
+}
+
 message ControlIDontWant {
     repeated bytes messageIDs = 1;
 }
 
-message PeerInfo {
-	optional bytes peerID = 1;
-	optional SignedPeerRecordEnvelope signedPeerRecord = 2;
+// Gossipsub v1.3 extension capabilities. Unknown fields are intentionally
+// ignored so future extensions remain wire compatible.
+message ControlExtensions {
+    optional bool partialMessages = 10;
+}
+
+// The Partial Messages extension uses an application-defined encoding for
+// message parts and metadata. topicID is a string to match the Go reference;
+// both it and the registry's bytes form use the same protobuf wire type.
+message PartialMessagesExtension {
+    optional string topicID = 1;
+    optional bytes groupID = 2;
+    optional bytes partialMessage = 3;
+    optional bytes partsMetadata = 4;
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.proto
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.proto
@@ -71,11 +71,10 @@ message ControlExtensions {
     optional bool partialMessages = 10;
 }
 
-// The Partial Messages extension uses an application-defined encoding for
-// message parts and metadata. topicID is a string to match the Go reference;
-// both it and the registry's bytes form use the same protobuf wire type.
+// The Partial Messages registry identifies topics as opaque bytes. Go's
+// current string declaration is wire compatible with this canonical form.
 message PartialMessagesExtension {
-    optional string topicID = 1;
+    optional bytes topicID = 1;
     optional bytes groupID = 2;
     optional bytes partialMessage = 3;
     optional bytes partsMetadata = 4;

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubProtocol.cs
@@ -117,3 +117,5 @@ public class GossipsubProtocol(PubsubRouter router, ILoggerFactory? loggerFactor
 public class GossipsubProtocolV11(PubsubRouter router, ILoggerFactory? loggerFactory = null) : PubsubProtocol(PubsubRouter.GossipsubProtocolVersionV11, router, loggerFactory);
 
 public class GossipsubProtocolV12(PubsubRouter router, ILoggerFactory? loggerFactory = null) : PubsubProtocol(PubsubRouter.GossipsubProtocolVersionV12, router, loggerFactory);
+
+public class GossipsubProtocolV13(PubsubRouter router, ILoggerFactory? loggerFactory = null) : PubsubProtocol(PubsubRouter.GossipsubProtocolVersionV13, router, loggerFactory);

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -77,12 +77,23 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
     private void HandleExtensions(PeerId peerId, Rpc rpc)
     {
-        if (!peerState.TryGetValue(peerId, out PubsubPeer? peer) || !peer.SupportsExtensions)
+        if (!peerState.TryGetValue(peerId, out PubsubPeer? peer))
         {
             return;
         }
 
         ControlExtensions? extensions = rpc.Control?.Extensions;
+        if (!peer.SupportsExtensions)
+        {
+            if (extensions is not null)
+            {
+                ApplyBehaviorPenalty(peerId, 1.0);
+                logger?.LogDebug("Ignoring Gossipsub v1.3 extensions from {peerId} on {protocol}", peerId, peer.Protocol);
+            }
+
+            return;
+        }
+
         if (peer.ReceivedFirstRpc)
         {
             if (extensions is not null)

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -19,6 +19,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             List<(string Topic, PeerId PeerId, byte[] Data)> receivedMessages = [];
             lock (this)
             {
+                HandleExtensions(peerId, rpc);
+
                 if (rpc.Publish.Count != 0)
                 {
                     HandleNewMessages(peerId, rpc.Publish, peerMessages, receivedMessages);
@@ -71,6 +73,28 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         {
             logger?.LogError(ex, "Exception while processing RPC");
         }
+    }
+
+    private void HandleExtensions(PeerId peerId, Rpc rpc)
+    {
+        if (!peerState.TryGetValue(peerId, out PubsubPeer? peer) || !peer.SupportsExtensions)
+        {
+            return;
+        }
+
+        ControlExtensions? extensions = rpc.Control?.Extensions;
+        if (peer.ReceivedFirstRpc)
+        {
+            if (extensions is not null)
+            {
+                ApplyBehaviorPenalty(peerId, 1.0);
+                logger?.LogDebug("Ignoring repeated Gossipsub v1.3 extensions from {peerId}", peerId);
+            }
+
+            return;
+        }
+
+        peer.ReceivedFirstRpc = true;
     }
 
     private void HandleNewMessages(PeerId peerId, IEnumerable<Message> messages, ConcurrentDictionary<PeerId, Rpc> peerMessages, List<(string Topic, PeerId PeerId, byte[] Data)> receivedMessages)
@@ -237,7 +261,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             {
                 ControlPrune prune = new() { TopicID = graft.TopicID, Backoff = (ulong)(_settings.PruneBackoff / 1000) };
 
-                if (peerState.TryGetValue(peerId, out PubsubPeer? peerData) && peerData.IsGossipSub && peerData.Protocol >= PubsubPeer.PubsubProtocol.GossipsubV11)
+                if (peerState.TryGetValue(peerId, out PubsubPeer? peerData) && peerData.SupportsPeerExchange)
                 {
                     peerData.Backoff[prune.TopicID] = DateTime.Now.AddMilliseconds(_settings.PruneBackoff);
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -31,6 +31,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     public const string GossipsubProtocolVersionV10 = "/meshsub/1.0.0";
     public const string GossipsubProtocolVersionV11 = "/meshsub/1.1.0";
     public const string GossipsubProtocolVersionV12 = "/meshsub/1.2.0";
+    public const string GossipsubProtocolVersionV13 = "/meshsub/1.3.0";
 
     class PubsubPeer
     {
@@ -43,6 +44,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 GossipsubProtocolVersionV10 => PubsubProtocol.GossipsubV10,
                 GossipsubProtocolVersionV11 => PubsubProtocol.GossipsubV11,
                 GossipsubProtocolVersionV12 => PubsubProtocol.GossipsubV12,
+                GossipsubProtocolVersionV13 => PubsubProtocol.GossipsubV13,
                 _ => PubsubProtocol.Floodsub,
             };
             TokenSource = new CancellationTokenSource();
@@ -58,7 +60,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             GossipsubV10 = 2,
             GossipsubV11 = 4,
             GossipsubV12 = 8,
-            AnyGossipsub = GossipsubV10 | GossipsubV11 | GossipsubV12,
+            GossipsubV13 = 16,
+            AnyGossipsub = GossipsubV10 | GossipsubV11 | GossipsubV12 | GossipsubV13,
         }
 
         public void Send(Rpc rpc)
@@ -79,6 +82,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         public ConcurrentQueue<Rpc> SendRpcQueue { get; }
         private Action<Rpc>? _sendRpc;
         private readonly ILogger? _logger;
+        public bool ReceivedFirstRpc { get; set; }
 
         public Action<Rpc>? SendRpc
         {
@@ -102,6 +106,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         public PubsubProtocol Protocol { get; set; }
         public bool IsGossipSub => (Protocol & PubsubProtocol.AnyGossipsub) != PubsubProtocol.None;
         public bool IsFloodSub => Protocol == PubsubProtocol.Floodsub;
+        public bool SupportsPeerExchange => Protocol is PubsubProtocol.GossipsubV11 or PubsubProtocol.GossipsubV12 or PubsubProtocol.GossipsubV13;
+        public bool SupportsExtensions => Protocol == PubsubProtocol.GossipsubV13;
 
         public ConnectionInitiation InitiatedBy { get; internal set; }
         public Multiaddress Address { get; internal set; } = null!;
@@ -237,7 +243,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             if (!peerState.ContainsKey(session.RemoteAddress.Get<P2P>().ToString()))
             {
                 string[]? protocols = _peerStore.GetPeerInfo(session.RemoteAddress.GetPeerId()!)?.SupportedProtocols ?? [];
-                if (protocols.Contains(GossipsubProtocolVersionV12))
+                if (protocols.Contains(GossipsubProtocolVersionV13))
+                {
+                    await session.DialAsync<GossipsubProtocolV13>(token);
+                }
+                else if (protocols.Contains(GossipsubProtocolVersionV12))
                 {
                     await session.DialAsync<GossipsubProtocolV12>(token);
                 }

--- a/src/libp2p/Libp2p/Libp2pPeerFactoryBuilder.cs
+++ b/src/libp2p/Libp2p/Libp2pPeerFactoryBuilder.cs
@@ -99,6 +99,7 @@ public class Libp2pPeerFactoryBuilder(IServiceProvider? serviceProvider = defaul
 
         ProtocolRef[] relay = addRelay ? [Get<RelayStopProtocol>(), Get<RelayHopProtocol>()] : [];
         ProtocolRef[] pubsub = addPubsub ? [
+            Get<GossipsubProtocolV13>(),
             Get<GossipsubProtocolV12>(),
             Get<GossipsubProtocolV11>(),
             Get<GossipsubProtocol>(),


### PR DESCRIPTION
## Summary
- register and prefer the /meshsub/1.3.0 protocol
- add the v1.3 extensions-control protobuf registry and first-RPC enforcement
- cover protocol selection and registry wire round-tripping

## Validation
- Pubsub protocol unit tests