### PR TITLE
Support Gossipsub partial messages

### DIFF
--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
@@ -5,6 +5,7 @@ using Google.Protobuf;
 using Multiformats.Address;
 using Nethermind.Libp2p.Core.Discovery;
 using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+using System.Collections.Concurrent;
 
 namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
 
@@ -23,6 +24,50 @@ public class PartialMessagesTests
         Assert.That(
             () => enabledRouter.GetPartialMessagesTopic("topic", new PartialMessagesTopicOptions { RequestPartialMessages = true }),
             Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void PartialMessageGossipCache_IsBoundedAndExpiresGroups()
+    {
+        PartialMessageGossipCache cache = new(maxGroupsPerTopic: 2, groupTtlHeartbeats: 2);
+
+        cache.Track("topic", [1]);
+        cache.Track("topic", [2]);
+        cache.Track("topic", [3]);
+
+        Assert.That(cache.GetGroupIds("topic"), Is.EqualTo(new[] { new byte[] { 2 }, new byte[] { 3 } }));
+
+        cache.Heartbeat();
+        Assert.That(cache.GetGroupIds("topic"), Has.Count.EqualTo(2));
+
+        cache.Heartbeat();
+        Assert.That(cache.GetGroupIds("topic"), Is.Empty);
+    }
+
+    [Test]
+    public async Task PartialMessages_ExtensionsAreAttachedToTheFirstConcurrentRpc()
+    {
+        PubsubRouter.PubsubPeer peer = new(
+            TestPeers.PeerId(1),
+            PubsubRouter.GossipsubProtocolVersionV13,
+            logger: null,
+            settings: new PubsubSettings { EnablePartialMessages = true });
+        ConcurrentQueue<Rpc> sentRpcs = [];
+        peer.SendRpc = sentRpcs.Enqueue;
+
+        using ManualResetEventSlim start = new(initialState: false);
+        Task[] sends = Enumerable.Range(0, 16)
+            .Select(_ => Task.Run(() =>
+            {
+                start.Wait();
+                peer.Send(new Rpc());
+            }))
+            .ToArray();
+        start.Set();
+        await Task.WhenAll(sends);
+
+        Assert.That(sentRpcs.TryPeek(out Rpc? first), Is.True);
+        Assert.That(first!.Control?.Extensions?.PartialMessages, Is.True);
     }
 
     [Test]
@@ -105,7 +150,7 @@ public class PartialMessagesTests
         {
             Partial = new PartialMessagesExtension
             {
-                TopicID = topicName,
+                TopicID = ByteString.CopyFromUtf8(topicName),
                 GroupID = ByteString.CopyFrom([1]),
                 PartialMessage = ByteString.CopyFrom([2]),
                 PartsMetadata = ByteString.CopyFrom([3]),
@@ -125,7 +170,7 @@ public class PartialMessagesTests
         {
             Partial = new PartialMessagesExtension
             {
-                TopicID = topicName,
+                TopicID = ByteString.CopyFromUtf8(topicName),
                 PartialMessage = ByteString.CopyFrom([2]),
             },
         });
@@ -133,7 +178,7 @@ public class PartialMessagesTests
         {
             Partial = new PartialMessagesExtension
             {
-                TopicID = topicName,
+                TopicID = ByteString.CopyFromUtf8(topicName),
                 GroupID = ByteString.CopyFrom([1]),
             },
         });
@@ -202,10 +247,11 @@ public class PartialMessagesTests
         {
             EnablePartialMessages = true,
             HeartbeatInterval = int.MaxValue,
-            LowestDegree = 0,
+            Degree = 1,
+            LowestDegree = 1,
             LazyDegree = 1,
         });
-        _ = router.GetPartialMessagesTopic(topicName, new PartialMessagesTopicOptions
+        IPartialMessagesTopic topic = router.GetPartialMessagesTopic(topicName, new PartialMessagesTopicOptions
         {
             RequestPartialMessages = true,
             SupportsSendingPartialMessages = true,
@@ -216,9 +262,11 @@ public class PartialMessagesTests
         TaskCompletionSource connection = new();
         Dictionary<PeerId, List<Rpc>> sentRpcs = [];
         List<PeerId>? partialGossipRecipients = null;
-        router.OnPartialGossip += (topic, peers) =>
+        byte[]? partialGossipGroupId = null;
+        router.OnPartialGossip += (topicId, groupId, peers) =>
         {
-            Assert.That(topic, Is.EqualTo(topicName));
+            Assert.That(topicId, Is.EqualTo(topicName));
+            partialGossipGroupId = groupId;
             partialGossipRecipients = peers.ToList();
         };
 
@@ -237,8 +285,13 @@ public class PartialMessagesTests
             peerRpcs.Clear();
         }
 
-        Identity author = TestPeers.Identity(4);
-        router.OnRpc(TestPeers.PeerId(1), new Rpc().WithMessages(topicName, 1, author.PeerId.Bytes, [1, 2, 3], author));
+        await router.Heartbeat();
+        foreach (List<Rpc> peerRpcs in sentRpcs.Values)
+        {
+            peerRpcs.Clear();
+        }
+
+        topic.PublishPartial([7, 8], partialMessage: [1, 2, 3]);
         foreach (List<Rpc> peerRpcs in sentRpcs.Values)
         {
             peerRpcs.Clear();
@@ -247,8 +300,75 @@ public class PartialMessagesTests
         await router.Heartbeat();
 
         Assert.That(partialGossipRecipients, Is.Not.Null.And.Not.Empty);
+        Assert.That(partialGossipGroupId, Is.EqualTo(new byte[] { 7, 8 }));
         Assert.That(partialGossipRecipients!.All(sentRpcs.ContainsKey), Is.True);
         Assert.That(sentRpcs.Values.SelectMany(rpcs => rpcs).SelectMany(rpc => rpc.Control?.Ihave ?? []), Is.Empty);
+
+        cancellation.Cancel();
+        connection.SetResult();
+    }
+
+    [Test]
+    public async Task PartialMessages_RequestersDoNotReceiveFullPublishesOrRelays()
+    {
+        const string topicName = "topic";
+        PubsubRouter router = new(new PeerStore(), new PubsubSettings
+        {
+            EnablePartialMessages = true,
+            HeartbeatInterval = int.MaxValue,
+            Degree = 3,
+            LowestDegree = 3,
+            HighestDegree = 3,
+        });
+        IPartialMessagesTopic topic = router.GetPartialMessagesTopic(topicName, new PartialMessagesTopicOptions
+        {
+            SupportsSendingPartialMessages = true,
+        });
+        using CancellationTokenSource cancellation = new();
+        await router.StartAsync(new LocalPeerStub(), cancellation.Token);
+
+        TaskCompletionSource connection = new();
+        Dictionary<PeerId, List<Rpc>> sentRpcs = [];
+        foreach (int peerNumber in Enumerable.Range(1, 3))
+        {
+            Multiaddress address = TestPeers.Multiaddr(peerNumber);
+            PeerId peerId = address.GetPeerId()!;
+            List<Rpc> peerRpcs = [];
+            sentRpcs.Add(peerId, peerRpcs);
+            router.OutboundConnection(address, PubsubRouter.GossipsubProtocolVersionV13, connection.Task, peerRpcs.Add);
+            router.OnRpc(peerId, CreateSubscriptionRpc(
+                topicName,
+                requestsPartialMessages: peerNumber == 1,
+                supportsSendingPartialMessages: true));
+        }
+
+        await router.Heartbeat();
+        foreach (List<Rpc> peerRpcs in sentRpcs.Values)
+        {
+            peerRpcs.Clear();
+        }
+
+        topic.Publish([1]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sentRpcs[TestPeers.PeerId(1)].SelectMany(rpc => rpc.Publish), Is.Empty);
+            Assert.That(sentRpcs[TestPeers.PeerId(2)].SelectMany(rpc => rpc.Publish).Count(), Is.EqualTo(1));
+        });
+
+        foreach (List<Rpc> peerRpcs in sentRpcs.Values)
+        {
+            peerRpcs.Clear();
+        }
+
+        Identity author = TestPeers.Identity(4);
+        router.OnRpc(TestPeers.PeerId(3), new Rpc().WithMessages(topicName, 1, author.PeerId.Bytes, [2], author));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sentRpcs[TestPeers.PeerId(1)].SelectMany(rpc => rpc.Publish), Is.Empty);
+            Assert.That(sentRpcs[TestPeers.PeerId(2)].SelectMany(rpc => rpc.Publish).Count(), Is.EqualTo(1));
+        });
 
         cancellation.Cancel();
         connection.SetResult();

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
@@ -144,6 +144,33 @@ public class PartialMessagesTests
     }
 
     [Test]
+    public void PartialMessages_HonorIndependentRemoteSubscriptionFlags()
+    {
+        const string topicName = "topic";
+        PubsubRouter router = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });
+        IPartialMessagesTopic topic = router.GetPartialMessagesTopic(
+            topicName,
+            new PartialMessagesTopicOptions { SupportsSendingPartialMessages = true });
+        Multiaddress remoteAddress = TestPeers.Multiaddr(1);
+        PeerId remotePeerId = remoteAddress.GetPeerId()!;
+        TaskCompletionSource connection = new();
+        List<Rpc> sentRpcs = [];
+        router.OutboundConnection(remoteAddress, PubsubRouter.GossipsubProtocolVersionV13, connection.Task, sentRpcs.Add);
+        router.OnRpc(remotePeerId, CreateSubscriptionRpc(topicName, requestsPartialMessages: true, supportsSendingPartialMessages: false));
+        sentRpcs.Clear();
+
+        topic.SendPartial(remotePeerId, [1], partialMessage: [2], partsMetadata: [3]);
+
+        PartialMessagesExtension sentPartial = sentRpcs.Single().Partial;
+        Assert.Multiple(() =>
+        {
+            Assert.That(sentPartial.PartialMessage.ToByteArray(), Is.EqualTo(new byte[] { 2 }));
+            Assert.That(sentPartial.HasPartsMetadata, Is.False);
+        });
+        connection.SetResult();
+    }
+
+    [Test]
     public void PartialMessages_AreNeverAdvertisedOnOlderProtocols()
     {
         PubsubRouter router = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Google.Protobuf;
+using Multiformats.Address;
+using Nethermind.Libp2p.Core.Discovery;
+using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
+
+[TestFixture]
+public class PartialMessagesTests
+{
+    [Test]
+    public void PartialMessagesTopics_RequireExplicitRouterAndTopicOptIn()
+    {
+        PubsubRouter disabledRouter = new(new PeerStore());
+        Assert.That(
+            () => disabledRouter.GetPartialMessagesTopic("topic", new PartialMessagesTopicOptions { SupportSendingPartialMessages = true }),
+            Throws.TypeOf<InvalidOperationException>());
+
+        PubsubRouter enabledRouter = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });
+        Assert.That(
+            () => enabledRouter.GetPartialMessagesTopic("topic", new PartialMessagesTopicOptions { RequestPartialMessages = true }),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public async Task PartialMessages_AdvertiseCapabilitiesAndGatePayloadsPerPeer()
+    {
+        const string topicName = "topic";
+        PubsubRouter router = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });
+        IPartialMessagesTopic topic = router.GetPartialMessagesTopic(
+            topicName,
+            new PartialMessagesTopicOptions
+            {
+                RequestPartialMessages = true,
+                SupportSendingPartialMessages = true,
+            });
+        await router.StartAsync(new LocalPeerStub());
+
+        List<Rpc> requestedPeerRpcs = [];
+        List<Rpc> metadataOnlyPeerRpcs = [];
+        TaskCompletionSource firstConnection = new();
+        TaskCompletionSource secondConnection = new();
+        Multiaddress requestedPeerAddress = TestPeers.Multiaddr(1);
+        Multiaddress metadataOnlyPeerAddress = TestPeers.Multiaddr(2);
+        PeerId requestedPeerId = requestedPeerAddress.GetPeerId()!;
+        PeerId metadataOnlyPeerId = metadataOnlyPeerAddress.GetPeerId()!;
+
+        router.OutboundConnection(requestedPeerAddress, PubsubRouter.GossipsubProtocolVersionV13, firstConnection.Task, requestedPeerRpcs.Add);
+        router.OutboundConnection(metadataOnlyPeerAddress, PubsubRouter.GossipsubProtocolVersionV13, secondConnection.Task, metadataOnlyPeerRpcs.Add);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(requestedPeerRpcs.Single().Control.Extensions.PartialMessages, Is.True);
+            Assert.That(requestedPeerRpcs.Single().Subscriptions.Single().RequestsPartial, Is.True);
+            Assert.That(requestedPeerRpcs.Single().Subscriptions.Single().SupportsSendingPartial, Is.True);
+            Assert.That(metadataOnlyPeerRpcs.Single().Control.Extensions.PartialMessages, Is.True);
+        });
+
+        router.OnRpc(requestedPeerId, CreateSubscriptionRpc(topicName, requestsPartialMessages: true, supportsSendingPartialMessages: true));
+        router.OnRpc(metadataOnlyPeerId, CreateSubscriptionRpc(topicName, requestsPartialMessages: false, supportsSendingPartialMessages: true));
+        requestedPeerRpcs.Clear();
+        metadataOnlyPeerRpcs.Clear();
+
+        topic.PublishPartial([1, 2], partialMessage: [3], partsMetadata: [4]);
+
+        PartialMessagesExtension requestedPartial = requestedPeerRpcs.Single().Partial;
+        PartialMessagesExtension metadataOnlyPartial = metadataOnlyPeerRpcs.Single().Partial;
+        Assert.Multiple(() =>
+        {
+            Assert.That(requestedPartial.GroupID.ToByteArray(), Is.EqualTo(new byte[] { 1, 2 }));
+            Assert.That(requestedPartial.PartialMessage.ToByteArray(), Is.EqualTo(new byte[] { 3 }));
+            Assert.That(requestedPartial.PartsMetadata.ToByteArray(), Is.EqualTo(new byte[] { 4 }));
+            Assert.That(metadataOnlyPartial.HasPartialMessage, Is.False);
+            Assert.That(metadataOnlyPartial.PartsMetadata.ToByteArray(), Is.EqualTo(new byte[] { 4 }));
+        });
+
+        firstConnection.SetResult();
+        secondConnection.SetResult();
+    }
+
+    [Test]
+    public void PartialMessages_AreForwardedAfterThePeerAdvertisesTheExtension()
+    {
+        const string topicName = "topic";
+        PubsubRouter router = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });
+        IPartialMessagesTopic topic = router.GetPartialMessagesTopic(
+            topicName,
+            new PartialMessagesTopicOptions { SupportSendingPartialMessages = true });
+        Multiaddress remoteAddress = TestPeers.Multiaddr(1);
+        PeerId remotePeerId = remoteAddress.GetPeerId()!;
+        TaskCompletionSource connection = new();
+        router.OutboundConnection(remoteAddress, PubsubRouter.GossipsubProtocolVersionV13, connection.Task, _ => { });
+
+        PartialMessage? received = null;
+        topic.OnPartialMessage += (_, message) => received = message;
+
+        router.OnRpc(remotePeerId, new Rpc
+        {
+            Control = new ControlMessage { Extensions = new ControlExtensions { PartialMessages = true } },
+        });
+        router.OnRpc(remotePeerId, new Rpc
+        {
+            Partial = new PartialMessagesExtension
+            {
+                TopicID = topicName,
+                GroupID = ByteString.CopyFrom([1]),
+                PartialMessage = ByteString.CopyFrom([2]),
+                PartsMetadata = ByteString.CopyFrom([3]),
+            },
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(received, Is.Not.Null);
+            Assert.That(received!.GroupId, Is.EqualTo(new byte[] { 1 }));
+            Assert.That(received.PartialData, Is.EqualTo(new byte[] { 2 }));
+            Assert.That(received.PartsMetadata, Is.EqualTo(new byte[] { 3 }));
+        });
+
+        connection.SetResult();
+    }
+
+    [Test]
+    public void PartialMessages_AreNeverAdvertisedOnOlderProtocols()
+    {
+        PubsubRouter router = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });
+        _ = router.GetPartialMessagesTopic("topic", new PartialMessagesTopicOptions { SupportSendingPartialMessages = true });
+        List<Rpc> sentRpcs = [];
+        TaskCompletionSource connection = new();
+
+        router.OutboundConnection(TestPeers.Multiaddr(1), PubsubRouter.GossipsubProtocolVersionV12, connection.Task, sentRpcs.Add);
+
+        Assert.That(sentRpcs.Single().Control, Is.Null);
+        connection.SetResult();
+    }
+
+    private static Rpc CreateSubscriptionRpc(string topicName, bool requestsPartialMessages, bool supportsSendingPartialMessages)
+    {
+        Rpc rpc = new()
+        {
+            Control = new ControlMessage { Extensions = new ControlExtensions { PartialMessages = true } },
+        };
+        rpc.Subscriptions.Add(new Rpc.Types.SubOpts
+        {
+            Subscribe = true,
+            Topicid = topicName,
+            RequestsPartial = requestsPartialMessages,
+            SupportsSendingPartial = supportsSendingPartialMessages,
+        });
+        return rpc;
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
@@ -16,7 +16,7 @@ public class PartialMessagesTests
     {
         PubsubRouter disabledRouter = new(new PeerStore());
         Assert.That(
-            () => disabledRouter.GetPartialMessagesTopic("topic", new PartialMessagesTopicOptions { SupportSendingPartialMessages = true }),
+            () => disabledRouter.GetPartialMessagesTopic("topic", new PartialMessagesTopicOptions { SupportsSendingPartialMessages = true }),
             Throws.TypeOf<InvalidOperationException>());
 
         PubsubRouter enabledRouter = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });
@@ -35,7 +35,7 @@ public class PartialMessagesTests
             new PartialMessagesTopicOptions
             {
                 RequestPartialMessages = true,
-                SupportSendingPartialMessages = true,
+                SupportsSendingPartialMessages = true,
             });
         await router.StartAsync(new LocalPeerStub());
 
@@ -88,7 +88,7 @@ public class PartialMessagesTests
         PubsubRouter router = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });
         IPartialMessagesTopic topic = router.GetPartialMessagesTopic(
             topicName,
-            new PartialMessagesTopicOptions { SupportSendingPartialMessages = true });
+            new PartialMessagesTopicOptions { SupportsSendingPartialMessages = true });
         Multiaddress remoteAddress = TestPeers.Multiaddr(1);
         PeerId remotePeerId = remoteAddress.GetPeerId()!;
         TaskCompletionSource connection = new();
@@ -120,6 +120,26 @@ public class PartialMessagesTests
             Assert.That(received.PartsMetadata, Is.EqualTo(new byte[] { 3 }));
         });
 
+        received = null;
+        router.OnRpc(remotePeerId, new Rpc
+        {
+            Partial = new PartialMessagesExtension
+            {
+                TopicID = topicName,
+                PartialMessage = ByteString.CopyFrom([2]),
+            },
+        });
+        router.OnRpc(remotePeerId, new Rpc
+        {
+            Partial = new PartialMessagesExtension
+            {
+                TopicID = topicName,
+                GroupID = ByteString.CopyFrom([1]),
+            },
+        });
+
+        Assert.That(received, Is.Null);
+
         connection.SetResult();
     }
 
@@ -127,13 +147,83 @@ public class PartialMessagesTests
     public void PartialMessages_AreNeverAdvertisedOnOlderProtocols()
     {
         PubsubRouter router = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });
-        _ = router.GetPartialMessagesTopic("topic", new PartialMessagesTopicOptions { SupportSendingPartialMessages = true });
+        _ = router.GetPartialMessagesTopic("topic", new PartialMessagesTopicOptions
+        {
+            RequestPartialMessages = true,
+            SupportsSendingPartialMessages = true,
+        });
         List<Rpc> sentRpcs = [];
         TaskCompletionSource connection = new();
 
         router.OutboundConnection(TestPeers.Multiaddr(1), PubsubRouter.GossipsubProtocolVersionV12, connection.Task, sentRpcs.Add);
 
-        Assert.That(sentRpcs.Single().Control, Is.Null);
+        Rpc.Types.SubOpts subscription = sentRpcs.Single().Subscriptions.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(sentRpcs.Single().Control, Is.Null);
+            Assert.That(subscription.HasRequestsPartial, Is.False);
+            Assert.That(subscription.HasSupportsSendingPartial, Is.False);
+        });
+        connection.SetResult();
+    }
+
+    [Test]
+    public async Task PartialMessages_GossipUsesTheApplicationCallbackInsteadOfIhave()
+    {
+        const string topicName = "topic";
+        PubsubRouter router = new(new PeerStore(), new PubsubSettings
+        {
+            EnablePartialMessages = true,
+            HeartbeatInterval = int.MaxValue,
+            LowestDegree = 0,
+            LazyDegree = 1,
+        });
+        _ = router.GetPartialMessagesTopic(topicName, new PartialMessagesTopicOptions
+        {
+            RequestPartialMessages = true,
+            SupportsSendingPartialMessages = true,
+        });
+        using CancellationTokenSource cancellation = new();
+        await router.StartAsync(new LocalPeerStub(), cancellation.Token);
+
+        TaskCompletionSource connection = new();
+        Dictionary<PeerId, List<Rpc>> sentRpcs = [];
+        List<PeerId>? partialGossipRecipients = null;
+        router.OnPartialGossip += (topic, peers) =>
+        {
+            Assert.That(topic, Is.EqualTo(topicName));
+            partialGossipRecipients = peers.ToList();
+        };
+
+        foreach (int peerNumber in Enumerable.Range(1, 3))
+        {
+            Multiaddress address = TestPeers.Multiaddr(peerNumber);
+            PeerId peerId = address.GetPeerId()!;
+            List<Rpc> peerRpcs = [];
+            sentRpcs.Add(peerId, peerRpcs);
+            router.OutboundConnection(address, PubsubRouter.GossipsubProtocolVersionV13, connection.Task, peerRpcs.Add);
+            router.OnRpc(peerId, CreateSubscriptionRpc(topicName, requestsPartialMessages: true, supportsSendingPartialMessages: true));
+        }
+
+        foreach (List<Rpc> peerRpcs in sentRpcs.Values)
+        {
+            peerRpcs.Clear();
+        }
+
+        Identity author = TestPeers.Identity(4);
+        router.OnRpc(TestPeers.PeerId(1), new Rpc().WithMessages(topicName, 1, author.PeerId.Bytes, [1, 2, 3], author));
+        foreach (List<Rpc> peerRpcs in sentRpcs.Values)
+        {
+            peerRpcs.Clear();
+        }
+
+        await router.Heartbeat();
+
+        Assert.That(partialGossipRecipients, Is.Not.Null.And.Not.Empty);
+        Assert.That(partialGossipRecipients!.All(sentRpcs.ContainsKey), Is.True);
+        Assert.That(sentRpcs.Values.SelectMany(rpcs => rpcs).SelectMany(rpc => rpc.Control?.Ihave ?? []), Is.Empty);
+
+        cancellation.Cancel();
         connection.SetResult();
     }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PartialMessagesTests.cs
@@ -27,6 +27,24 @@ public class PartialMessagesTests
     }
 
     [Test]
+    public void GetTopic_DoesNotExposePartialMessagesWithoutTheExplicitApi()
+    {
+        PubsubRouter router = new(new PeerStore(), new PubsubSettings { EnablePartialMessages = true });
+        ITopic topic = router.GetTopic("topic");
+
+        IPartialMessagesTopic partialTopic = router.GetPartialMessagesTopic(
+            "topic",
+            new PartialMessagesTopicOptions { SupportsSendingPartialMessages = true });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(topic, Is.Not.InstanceOf<IPartialMessagesTopic>());
+            Assert.That(partialTopic, Is.Not.SameAs(topic));
+            Assert.That(partialTopic.IsSubscribed, Is.True);
+        });
+    }
+
+    [Test]
     public void PartialMessageGossipCache_IsBoundedAndExpiresGroups()
     {
         PartialMessageGossipCache cache = new(maxGroupsPerTopic: 2, groupTtlHeartbeats: 2);

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.cs
@@ -3166,8 +3166,9 @@ namespace Nethermind.Libp2p.Protocols.Pubsub.Dto {
   }
 
   /// <summary>
-  /// The Partial Messages registry identifies topics as opaque bytes. Go's
-  /// current string declaration is wire compatible with this canonical form.
+  /// The Partial Messages registry identifies topics as opaque bytes. The base
+  /// pubsub API uses UTF-8 topic strings, so the router validates and decodes this
+  /// field at its boundary. Go's current string declaration is wire compatible.
   /// </summary>
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PartialMessagesExtension : pb::IMessage<PartialMessagesExtension>

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.proto
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Dto/Rpc.proto
@@ -71,8 +71,9 @@ message ControlExtensions {
     optional bool partialMessages = 10;
 }
 
-// The Partial Messages registry identifies topics as opaque bytes. Go's
-// current string declaration is wire compatible with this canonical form.
+// The Partial Messages registry identifies topics as opaque bytes. The base
+// pubsub API uses UTF-8 topic strings, so the router validates and decodes this
+// field at its boundary. Go's current string declaration is wire compatible.
 message PartialMessagesExtension {
     optional bytes topicID = 1;
     optional bytes groupID = 2;

--- a/src/libp2p/Libp2p.Protocols.Pubsub/IPartialMessagesTopic.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/IPartialMessagesTopic.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Nethermind.Libp2p.Core;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub;
+
+/// <summary>
+/// A topic configured for the Gossipsub v1.3 Partial Messages extension.
+/// </summary>
+public interface IPartialMessagesTopic : ITopic
+{
+    /// <summary>
+    /// Raised for application-defined partial message payloads received for this topic.
+    /// </summary>
+    event Action<PeerId, PartialMessage>? OnPartialMessage;
+
+    bool RequestsPartialMessages { get; }
+    bool SupportsSendingPartialMessages { get; }
+
+    /// <summary>
+    /// Sends an application-defined partial message to the topic mesh or fanout peers.
+    /// </summary>
+    void PublishPartial(byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null);
+
+    /// <summary>
+    /// Sends an application-defined partial message to a connected peer, including
+    /// a non-mesh peer selected by application gossip logic.
+    /// </summary>
+    void SendPartial(PeerId peerId, byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null);
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PartialMessage.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PartialMessage.cs
@@ -39,5 +39,5 @@ public sealed class PartialMessagesTopicOptions
     /// <summary>
     /// Signals that this topic can send partial data and receive parts metadata.
     /// </summary>
-    public bool SupportSendingPartialMessages { get; init; }
+    public bool SupportsSendingPartialMessages { get; init; }
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PartialMessage.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PartialMessage.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+namespace Nethermind.Libp2p.Protocols.Pubsub;
+
+/// <summary>
+/// Application-defined data carried by the Gossipsub v1.3 Partial Messages extension.
+/// </summary>
+public sealed class PartialMessage
+{
+    public PartialMessage(string topicId, byte[] groupId, byte[]? partialData, byte[]? partsMetadata)
+    {
+        ArgumentNullException.ThrowIfNull(topicId);
+        ArgumentNullException.ThrowIfNull(groupId);
+
+        TopicId = topicId;
+        GroupId = groupId;
+        PartialData = partialData;
+        PartsMetadata = partsMetadata;
+    }
+
+    public string TopicId { get; }
+    public byte[] GroupId { get; }
+    public byte[]? PartialData { get; }
+    public byte[]? PartsMetadata { get; }
+}
+
+/// <summary>
+/// Per-topic capabilities advertised through Gossipsub subscription options.
+/// </summary>
+public sealed class PartialMessagesTopicOptions
+{
+    /// <summary>
+    /// Requests partial data from peers. This also requires support for sending
+    /// partial messages.
+    /// </summary>
+    public bool RequestPartialMessages { get; init; }
+
+    /// <summary>
+    /// Signals that this topic can send partial data and receive parts metadata.
+    /// </summary>
+    public bool SupportSendingPartialMessages { get; init; }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PartialMessageGossipCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PartialMessageGossipCache.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+namespace Nethermind.Libp2p.Protocols.Pubsub;
+
+/// <summary>
+/// Bounded local partial-message group state used to give applications concrete
+/// group identifiers when gossiping to non-mesh peers.
+/// </summary>
+internal sealed class PartialMessageGossipCache
+{
+    private sealed class Group(byte[] id, int remainingHeartbeats)
+    {
+        public byte[] Id { get; } = id;
+        public int RemainingHeartbeats { get; set; } = remainingHeartbeats;
+        public LinkedListNode<Group>? AgeNode { get; set; }
+    }
+
+    private sealed class TopicGroups
+    {
+        public Dictionary<string, Group> ById { get; } = [];
+        public LinkedList<Group> ByAge { get; } = [];
+    }
+
+    private readonly Dictionary<string, TopicGroups> topics = [];
+    private readonly int maxGroupsPerTopic;
+    private readonly int groupTtlHeartbeats;
+
+    public PartialMessageGossipCache(int maxGroupsPerTopic, int groupTtlHeartbeats)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxGroupsPerTopic);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(groupTtlHeartbeats);
+        this.maxGroupsPerTopic = maxGroupsPerTopic;
+        this.groupTtlHeartbeats = groupTtlHeartbeats;
+    }
+
+    public void Track(string topic, ReadOnlySpan<byte> groupId)
+    {
+        TopicGroups groups = topics.GetValueOrDefault(topic) ?? CreateTopic(topic);
+        string key = Convert.ToHexString(groupId);
+        if (groups.ById.TryGetValue(key, out Group? existing))
+        {
+            existing.RemainingHeartbeats = groupTtlHeartbeats;
+            groups.ByAge.Remove(existing.AgeNode!);
+            existing.AgeNode = groups.ByAge.AddLast(existing);
+            return;
+        }
+
+        if (groups.ById.Count == maxGroupsPerTopic)
+        {
+            Remove(groups, groups.ByAge.First!.Value);
+        }
+
+        Group group = new(groupId.ToArray(), groupTtlHeartbeats);
+        group.AgeNode = groups.ByAge.AddLast(group);
+        groups.ById.Add(key, group);
+    }
+
+    public IReadOnlyList<byte[]> GetGroupIds(string topic)
+    {
+        return topics.TryGetValue(topic, out TopicGroups? groups)
+            ? groups.ByAge.Select(group => group.Id.ToArray()).ToArray()
+            : [];
+    }
+
+    public void Heartbeat()
+    {
+        foreach ((string topic, TopicGroups groups) in topics.ToArray())
+        {
+            LinkedListNode<Group>? node = groups.ByAge.First;
+            while (node is not null)
+            {
+                LinkedListNode<Group>? next = node.Next;
+                Group group = node.Value;
+                group.RemainingHeartbeats--;
+                if (group.RemainingHeartbeats == 0)
+                {
+                    Remove(groups, group);
+                }
+
+                node = next;
+            }
+
+            if (groups.ById.Count == 0)
+            {
+                topics.Remove(topic);
+            }
+        }
+    }
+
+    private TopicGroups CreateTopic(string topic)
+    {
+        TopicGroups groups = new();
+        topics.Add(topic, groups);
+        return groups;
+    }
+
+    private static void Remove(TopicGroups groups, Group group)
+    {
+        groups.ById.Remove(Convert.ToHexString(group.Id));
+        groups.ByAge.Remove(group.AgeNode!);
+        group.AgeNode = null;
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -46,6 +46,12 @@ public class PubsubSettings
     /// </summary>
     public bool EnablePartialMessages { get; set; }
 
+    /// <summary>Number of heartbeats to retain a locally published partial-message group for gossip.</summary>
+    public int PartialMessageGossipTtlHeartbeats { get; set; } = 3;
+
+    /// <summary>Maximum locally published partial-message groups retained for one topic.</summary>
+    public int MaxPartialMessageGroupsPerTopic { get; set; } = 255;
+
     public Func<Message, MessageId> GetMessageId { get; set; } = ConcatFromAndSeqno;
 
     public enum SignaturePolicy

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -40,6 +40,12 @@ public class PubsubSettings
     public SignaturePolicy DefaultSignaturePolicy { get; set; } = SignaturePolicy.StrictSign;
     public int MaxIdontwantMessages { get; set; } = 50;
 
+    /// <summary>
+    /// Enables the opt-in Gossipsub v1.3 Partial Messages extension. The router
+    /// advertises it only to v1.3 peers.
+    /// </summary>
+    public bool EnablePartialMessages { get; set; }
+
     public Func<Message, MessageId> GetMessageId { get; set; } = ConcatFromAndSeqno;
 
     public enum SignaturePolicy

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -261,7 +261,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     state.UpdatePartialMessagesSubscription(
                         sub.Topicid,
                         requestsPartialMessages,
-                        requestsPartialMessages || sub.SupportsSendingPartial);
+                        sub.SupportsSendingPartial);
                 }
             }
             else

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -17,6 +17,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         {
             ConcurrentDictionary<PeerId, Rpc> peerMessages = new();
             List<(string Topic, PeerId PeerId, byte[] Data)> receivedMessages = [];
+            List<(string Topic, PeerId PeerId, PartialMessage Message)> receivedPartialMessages = [];
             lock (this)
             {
                 HandleExtensions(peerId, rpc);
@@ -29,6 +30,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 if (rpc.Subscriptions.Count != 0)
                 {
                     HandleSubscriptions(peerId, rpc.Subscriptions);
+                }
+
+                if (rpc.Partial is not null)
+                {
+                    HandlePartialMessage(peerId, rpc.Partial, receivedPartialMessages);
                 }
 
                 if (rpc.Control is not null)
@@ -62,6 +68,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             foreach ((string topic, PeerId receivedFrom, byte[] data) in receivedMessages)
             {
                 OnMessage?.Invoke(topic, receivedFrom, data);
+            }
+
+            foreach ((string topic, PeerId receivedFrom, PartialMessage message) in receivedPartialMessages)
+            {
+                OnPartialMessage?.Invoke(topic, receivedFrom, message);
             }
 
             foreach (KeyValuePair<PeerId, Rpc> peerMessage in peerMessages)
@@ -106,6 +117,32 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         }
 
         peer.ReceivedFirstRpc = true;
+        peer.SupportsPartialMessagesExtension = extensions?.PartialMessages ?? false;
+    }
+
+    private void HandlePartialMessage(PeerId peerId, PartialMessagesExtension partialMessage, List<(string Topic, PeerId PeerId, PartialMessage Message)> receivedPartialMessages)
+    {
+        if (!_settings.EnablePartialMessages ||
+            !peerState.TryGetValue(peerId, out PubsubPeer? peer) ||
+            !peer.SupportsPartialMessagesExtension)
+        {
+            return;
+        }
+
+        if (!partialMessage.HasTopicID)
+        {
+            logger?.LogDebug("Ignoring a Partial Messages extension payload without a topic from {peerId}", peerId);
+            return;
+        }
+
+        receivedPartialMessages.Add((
+            partialMessage.TopicID,
+            peerId,
+            new PartialMessage(
+                partialMessage.TopicID,
+                partialMessage.GroupID.ToByteArray(),
+                partialMessage.HasPartialMessage ? partialMessage.PartialMessage.ToByteArray() : null,
+                partialMessage.HasPartsMetadata ? partialMessage.PartsMetadata.ToByteArray() : null)));
     }
 
     private void HandleNewMessages(PeerId peerId, IEnumerable<Message> messages, ConcurrentDictionary<PeerId, Rpc> peerMessages, List<(string Topic, PeerId PeerId, byte[] Data)> receivedMessages)
@@ -215,9 +252,19 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 {
                     fPeers.GetOrAdd(sub.Topicid, _ => []).Add(peerId);
                 }
+
+                if (_settings.EnablePartialMessages && state.SupportsPartialMessagesExtension)
+                {
+                    bool requestsPartialMessages = sub.RequestsPartial;
+                    state.UpdatePartialMessagesSubscription(
+                        sub.Topicid,
+                        requestsPartialMessages,
+                        requestsPartialMessages || sub.SupportsSendingPartial);
+                }
             }
             else
             {
+                state.RemovePartialMessagesSubscription(sub.Topicid);
                 if (state.IsGossipSub)
                 {
                     gPeers.GetOrAdd(sub.Topicid, _ => []).Remove(peerId);

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -6,11 +6,14 @@ using Microsoft.Extensions.Logging;
 using Nethermind.Libp2p.Core;
 using Nethermind.Libp2p.Protocols.Pubsub.Dto;
 using System.Collections.Concurrent;
+using System.Text;
 
 namespace Nethermind.Libp2p.Protocols.Pubsub;
 
 public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 {
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
     internal void OnRpc(PeerId peerId, Rpc rpc)
     {
         try
@@ -137,11 +140,17 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             return;
         }
 
+        if (!TryDecodeTopicId(partialMessage.TopicID, out string topicId))
+        {
+            logger?.LogDebug("Ignoring a Partial Messages extension payload with a non-UTF-8 topic from {peerId}", peerId);
+            return;
+        }
+
         receivedPartialMessages.Add((
-            partialMessage.TopicID,
+            topicId,
             peerId,
             new PartialMessage(
-                partialMessage.TopicID,
+                topicId,
                 partialMessage.GroupID.ToByteArray(),
                 partialMessage.HasPartialMessage ? partialMessage.PartialMessage.ToByteArray() : null,
                 partialMessage.HasPartsMetadata ? partialMessage.PartsMetadata.ToByteArray() : null)));
@@ -213,7 +222,10 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     {
                         continue;
                     }
-                    peerMessages.GetOrAdd(peer, _ => new Rpc()).Publish.Add(message);
+                    if (ShouldSendFullMessage(peer, message.Topic))
+                    {
+                        peerMessages.GetOrAdd(peer, _ => new Rpc()).Publish.Add(message);
+                    }
                 }
             }
             if (mesh.TryGetValue(message.Topic, out topicPeers))
@@ -226,12 +238,26 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     }
 
                     // Only forward to peers above publish threshold (Gossipsub v1.1)
-                    if (GetPeerScore(peer) >= _settings.PublishThreshold)
+                    if (GetPeerScore(peer) >= _settings.PublishThreshold && ShouldSendFullMessage(peer, message.Topic))
                     {
                         peerMessages.GetOrAdd(peer, _ => new Rpc()).Publish.Add(message);
                     }
                 }
             }
+        }
+    }
+
+    private static bool TryDecodeTopicId(ByteString topicIdBytes, out string topicId)
+    {
+        try
+        {
+            topicId = StrictUtf8.GetString(topicIdBytes.Span);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            topicId = string.Empty;
+            return false;
         }
     }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -129,9 +129,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             return;
         }
 
-        if (!partialMessage.HasTopicID)
+        if (!partialMessage.HasTopicID ||
+            !partialMessage.HasGroupID ||
+            (!partialMessage.HasPartialMessage && !partialMessage.HasPartsMetadata))
         {
-            logger?.LogDebug("Ignoring a Partial Messages extension payload without a topic from {peerId}", peerId);
+            logger?.LogDebug("Ignoring an incomplete Partial Messages extension payload from {peerId}", peerId);
             return;
         }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -184,10 +184,13 @@ public partial class PubsubRouter
             ulong seqNo = this.seqNo++;
             Rpc rpc = new Rpc().WithMessages(topicId, seqNo, localPeer.Identity.PeerId.Bytes, message, localPeer.Identity);
 
-            // Floodsub peers always get the message
+            // Floodsub peers always get the message.
             foreach (PeerId peerId in fPeers.GetValueOrDefault(topicId) ?? [])
             {
-                peerState.GetValueOrDefault(peerId)?.Send(rpc);
+                if (ShouldSendFullMessage(peerId, topicId))
+                {
+                    peerState.GetValueOrDefault(peerId)?.Send(rpc);
+                }
             }
 
             // Gossipsub v1.1: Flood publishing
@@ -196,7 +199,18 @@ public partial class PubsubRouter
                 // Send to all gossipsub peers above publish threshold
                 foreach (PeerId peerId in allGossipsubPeers)
                 {
-                    if (GetPeerScore(peerId) >= _settings.PublishThreshold)
+                    if (GetPeerScore(peerId) >= _settings.PublishThreshold && ShouldSendFullMessage(peerId, topicId))
+                    {
+                        peerState.GetValueOrDefault(peerId)?.Send(rpc);
+                    }
+                }
+            }
+            else if (mesh.TryGetValue(topicId, out HashSet<PeerId>? meshPeers))
+            {
+                // Standard gossipsub v1.0 behavior: send to mesh or fanout
+                foreach (PeerId peerId in meshPeers)
+                {
+                    if (GetPeerScore(peerId) >= _settings.PublishThreshold && ShouldSendFullMessage(peerId, topicId))
                     {
                         peerState.GetValueOrDefault(peerId)?.Send(rpc);
                     }
@@ -204,42 +218,28 @@ public partial class PubsubRouter
             }
             else
             {
-                // Standard gossipsub v1.0 behavior: send to mesh or fanout
-                if (mesh.TryGetValue(topicId, out HashSet<PeerId>? meshPeers))
+                fanoutLastPublished[topicId] = DateTime.Now;
+                HashSet<PeerId> topicFanout = fanout.GetOrAdd(topicId, _ => []);
+
+                if (topicFanout.Count == 0)
                 {
-                    foreach (PeerId peerId in meshPeers)
+                    HashSet<PeerId>? topicPeers = gPeers.GetValueOrDefault(topicId);
+                    if (topicPeers is { Count: > 0 })
                     {
-                        if (GetPeerScore(peerId) >= _settings.PublishThreshold)
+                        // Select peers with non-negative scores
+                        var eligiblePeers = topicPeers.Where(p => GetPeerScore(p) >= 0).ToList();
+                        foreach (PeerId peer in eligiblePeers.Take(_settings.Degree))
                         {
-                            peerState.GetValueOrDefault(peerId)?.Send(rpc);
+                            topicFanout.Add(peer);
                         }
                     }
                 }
-                else
+
+                foreach (PeerId peerId in topicFanout)
                 {
-                    fanoutLastPublished[topicId] = DateTime.Now;
-                    HashSet<PeerId> topicFanout = fanout.GetOrAdd(topicId, _ => []);
-
-                    if (topicFanout.Count == 0)
+                    if (GetPeerScore(peerId) >= _settings.PublishThreshold && ShouldSendFullMessage(peerId, topicId))
                     {
-                        HashSet<PeerId>? topicPeers = gPeers.GetValueOrDefault(topicId);
-                        if (topicPeers is { Count: > 0 })
-                        {
-                            // Select peers with non-negative scores
-                            var eligiblePeers = topicPeers.Where(p => GetPeerScore(p) >= 0).ToList();
-                            foreach (PeerId peer in eligiblePeers.Take(_settings.Degree))
-                            {
-                                topicFanout.Add(peer);
-                            }
-                        }
-                    }
-
-                    foreach (PeerId peerId in topicFanout)
-                    {
-                        if (GetPeerScore(peerId) >= _settings.PublishThreshold)
-                        {
-                            peerState.GetValueOrDefault(peerId)?.Send(rpc);
-                        }
+                        peerState.GetValueOrDefault(peerId)?.Send(rpc);
                     }
                 }
             }
@@ -257,6 +257,11 @@ public partial class PubsubRouter
         if (localPeer is null)
         {
             throw new InvalidOperationException("Router has not been started. Call StartAsync() first.");
+        }
+
+        lock (this)
+        {
+            partialMessageGossip.Track(topicId, groupId);
         }
 
         PeerId[] recipients;
@@ -307,7 +312,7 @@ public partial class PubsubRouter
 
         PartialMessagesExtension partial = new()
         {
-            TopicID = topicId,
+            TopicID = Google.Protobuf.ByteString.CopyFromUtf8(topicId),
             GroupID = Google.Protobuf.ByteString.CopyFrom(groupId),
         };
         if (sendPartialData && partialMessage is not null)
@@ -335,6 +340,16 @@ public partial class PubsubRouter
         {
             throw new InvalidOperationException($"Partial messages are not enabled for topic '{topicId}'.");
         }
+    }
+
+    private bool ShouldSendFullMessage(PeerId peerId, string topicId)
+    {
+        return !_settings.EnablePartialMessages ||
+            !topicState.TryGetValue(topicId, out Topic? topic) ||
+            !topic.SupportsSendingPartialMessages ||
+            !peerState.TryGetValue(peerId, out PubsubPeer? peer) ||
+            !peer.SupportsPartialMessagesExtension ||
+            !peer.RequestsPartialMessages(topicId);
     }
 
     private static void ValidatePartialMessage(byte[] groupId, byte[]? partialMessage, byte[]? partsMetadata)

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -58,8 +58,15 @@ public partial class PubsubRouter
         Rpc.Types.SubOpts subscription = new() { Subscribe = subscribe, Topicid = topicId };
         if (subscribe && _settings.EnablePartialMessages && topicState.TryGetValue(topicId, out Topic? topic))
         {
-            subscription.RequestsPartial = topic.RequestsPartialMessages;
-            subscription.SupportsSendingPartial = topic.SupportsSendingPartialMessages;
+            if (topic.RequestsPartialMessages)
+            {
+                subscription.RequestsPartial = true;
+            }
+
+            if (topic.SupportsSendingPartialMessages)
+            {
+                subscription.SupportsSendingPartial = true;
+            }
         }
 
         return subscription;

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -24,6 +24,57 @@ public partial class PubsubRouter
         return topic;
     }
 
+    /// <summary>
+    /// Gets a topic configured for the opt-in Gossipsub v1.3 Partial Messages extension.
+    /// </summary>
+    public IPartialMessagesTopic GetPartialMessagesTopic(string topicId, PartialMessagesTopicOptions options, bool subscribe = true)
+    {
+        ArgumentNullException.ThrowIfNull(topicId);
+        ArgumentNullException.ThrowIfNull(options);
+        if (!_settings.EnablePartialMessages)
+        {
+            throw new InvalidOperationException("Partial messages are not enabled. Set EnablePartialMessages before creating a partial messages topic.");
+        }
+
+        Topic topic = topicState.GetOrAdd(topicId, (tId) => new(this, tId));
+        bool wasSubscribed = topic.IsSubscribed;
+        topic.ConfigurePartialMessages(options);
+
+        if (subscribe)
+        {
+            Subscribe(topicId);
+        }
+
+        if (wasSubscribed)
+        {
+            AnnounceSubscription(topicId);
+        }
+
+        return topic;
+    }
+
+    private Rpc.Types.SubOpts CreateSubscription(string topicId, bool subscribe)
+    {
+        Rpc.Types.SubOpts subscription = new() { Subscribe = subscribe, Topicid = topicId };
+        if (subscribe && _settings.EnablePartialMessages && topicState.TryGetValue(topicId, out Topic? topic))
+        {
+            subscription.RequestsPartial = topic.RequestsPartialMessages;
+            subscription.SupportsSendingPartial = topic.SupportsSendingPartialMessages;
+        }
+
+        return subscription;
+    }
+
+    private void AnnounceSubscription(string topicId)
+    {
+        Rpc topicUpdate = new();
+        topicUpdate.Subscriptions.Add(CreateSubscription(topicId, subscribe: true));
+        foreach (KeyValuePair<PeerId, PubsubPeer> peer in peerState)
+        {
+            peer.Value.Send(topicUpdate);
+        }
+    }
+
     public void Subscribe(string topicId)
     {
         lock (this)
@@ -54,7 +105,8 @@ public partial class PubsubRouter
                 fanoutLastPublished.TryRemove(topicId, out _);
             }
 
-            Rpc topicUpdate = new Rpc().WithTopics([topicId], []);
+            Rpc topicUpdate = new();
+            topicUpdate.Subscriptions.Add(CreateSubscription(topicId, subscribe: true));
             foreach (PubsubPeer peer in peerState.Values)
             {
                 peer.Send(topicUpdate);
@@ -184,6 +236,106 @@ public partial class PubsubRouter
                     }
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Sends application-defined partial data to partial-message-capable mesh or fanout peers.
+    /// </summary>
+    public void PublishPartial(string topicId, byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null)
+    {
+        EnsurePartialMessagesEnabled(topicId);
+        ValidatePartialMessage(groupId, partialMessage, partsMetadata);
+
+        if (localPeer is null)
+        {
+            throw new InvalidOperationException("Router has not been started. Call StartAsync() first.");
+        }
+
+        PeerId[] recipients;
+        if (mesh.TryGetValue(topicId, out HashSet<PeerId>? meshPeers) && meshPeers.Count > 0)
+        {
+            recipients = meshPeers.Where(peerId => GetPeerScore(peerId) >= _settings.PublishThreshold).ToArray();
+        }
+        else
+        {
+            fanoutLastPublished[topicId] = DateTime.Now;
+            HashSet<PeerId> fanoutPeers = fanout.GetOrAdd(topicId, _ => []);
+            if (fanoutPeers.Count == 0 && gPeers.TryGetValue(topicId, out HashSet<PeerId>? topicPeers))
+            {
+                foreach (PeerId peerId in topicPeers.Where(peerId => GetPeerScore(peerId) >= 0).Take(_settings.Degree))
+                {
+                    fanoutPeers.Add(peerId);
+                }
+            }
+
+            recipients = fanoutPeers.Where(peerId => GetPeerScore(peerId) >= _settings.PublishThreshold).ToArray();
+        }
+
+        foreach (PeerId peerId in recipients)
+        {
+            SendPartial(peerId, topicId, groupId, partialMessage, partsMetadata);
+        }
+    }
+
+    /// <summary>
+    /// Sends application-defined partial data to a connected peer selected by the application.
+    /// </summary>
+    public void SendPartial(PeerId peerId, string topicId, byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null)
+    {
+        EnsurePartialMessagesEnabled(topicId);
+        ValidatePartialMessage(groupId, partialMessage, partsMetadata);
+
+        if (!peerState.TryGetValue(peerId, out PubsubPeer? peer) || !peer.SupportsPartialMessagesExtension)
+        {
+            return;
+        }
+
+        bool sendPartialData = peer.RequestsPartialMessages(topicId);
+        bool sendPartsMetadata = peer.SupportsSendingPartialMessages(topicId);
+        if (!sendPartialData && !sendPartsMetadata)
+        {
+            return;
+        }
+
+        PartialMessagesExtension partial = new()
+        {
+            TopicID = topicId,
+            GroupID = Google.Protobuf.ByteString.CopyFrom(groupId),
+        };
+        if (sendPartialData && partialMessage is not null)
+        {
+            partial.PartialMessage = Google.Protobuf.ByteString.CopyFrom(partialMessage);
+        }
+
+        if (sendPartsMetadata && partsMetadata is not null)
+        {
+            partial.PartsMetadata = Google.Protobuf.ByteString.CopyFrom(partsMetadata);
+        }
+
+        if (partial.HasPartialMessage || partial.HasPartsMetadata)
+        {
+            peer.Send(new Rpc { Partial = partial });
+        }
+    }
+
+    private void EnsurePartialMessagesEnabled(string topicId)
+    {
+        ArgumentNullException.ThrowIfNull(topicId);
+        if (!_settings.EnablePartialMessages ||
+            !topicState.TryGetValue(topicId, out Topic? topic) ||
+            !topic.SupportsSendingPartialMessages)
+        {
+            throw new InvalidOperationException($"Partial messages are not enabled for topic '{topicId}'.");
+        }
+    }
+
+    private static void ValidatePartialMessage(byte[] groupId, byte[]? partialMessage, byte[]? partsMetadata)
+    {
+        ArgumentNullException.ThrowIfNull(groupId);
+        if (partialMessage is null && partsMetadata is null)
+        {
+            throw new ArgumentException("A partial message or parts metadata must be supplied.");
         }
     }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -38,7 +38,7 @@ public partial class PubsubRouter
 
         Topic topic = topicState.GetOrAdd(topicId, (tId) => new(this, tId));
         bool wasSubscribed = topic.IsSubscribed;
-        topic.ConfigurePartialMessages(options);
+        IPartialMessagesTopic partialMessagesTopic = topic.ConfigurePartialMessages(options);
 
         if (subscribe)
         {
@@ -50,7 +50,7 @@ public partial class PubsubRouter
             AnnounceSubscription(topicId);
         }
 
-        return topic;
+        return partialMessagesTopic;
     }
 
     private Rpc.Types.SubOpts CreateSubscription(string topicId, bool subscribe)

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -74,11 +74,19 @@ public partial class PubsubRouter
 
     private void AnnounceSubscription(string topicId)
     {
-        Rpc topicUpdate = new();
-        topicUpdate.Subscriptions.Add(CreateSubscription(topicId, subscribe: true));
-        foreach (KeyValuePair<PeerId, PubsubPeer> peer in peerState)
+        lock (this)
         {
-            peer.Value.Send(topicUpdate);
+            if (topicState.GetValueOrDefault(topicId)?.IsSubscribed is not true)
+            {
+                return;
+            }
+
+            Rpc topicUpdate = new();
+            topicUpdate.Subscriptions.Add(CreateSubscription(topicId, subscribe: true));
+            foreach (KeyValuePair<PeerId, PubsubPeer> peer in peerState)
+            {
+                peer.Value.Send(topicUpdate);
+            }
         }
     }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -47,6 +47,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 GossipsubProtocolVersionV13 => PubsubProtocol.GossipsubV13,
                 _ => PubsubProtocol.Floodsub,
             };
+            _advertisesPartialMessages = settings.EnablePartialMessages;
             TokenSource = new CancellationTokenSource();
             Backoff = [];
             SendRpcQueue = new ConcurrentQueue<Rpc>();
@@ -66,6 +67,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
         public void Send(Rpc rpc)
         {
+            rpc = AddExtensionsIfNeeded(rpc);
             SendRpcQueue.Enqueue(rpc);
             if (SendRpc is not null)
             {
@@ -82,7 +84,69 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         public ConcurrentQueue<Rpc> SendRpcQueue { get; }
         private Action<Rpc>? _sendRpc;
         private readonly ILogger? _logger;
+        private readonly bool _advertisesPartialMessages;
+        private readonly object _extensionsLock = new();
+        private readonly ConcurrentDictionary<string, PartialMessagesSubscription> _partialMessagesSubscriptions = new();
+
+        private readonly record struct PartialMessagesSubscription(bool RequestsPartialMessages, bool SupportsSendingPartialMessages);
+
+        public bool ExtensionsSent { get; private set; }
         public bool ReceivedFirstRpc { get; set; }
+        public bool SupportsPartialMessagesExtension { get; set; }
+
+        public bool NeedsExtensions
+        {
+            get
+            {
+                lock (_extensionsLock)
+                {
+                    return _advertisesPartialMessages && SupportsExtensions && !ExtensionsSent;
+                }
+            }
+        }
+
+        public void UpdatePartialMessagesSubscription(string topicId, bool requestsPartialMessages, bool supportsSendingPartialMessages)
+        {
+            _partialMessagesSubscriptions[topicId] = new(requestsPartialMessages, supportsSendingPartialMessages);
+        }
+
+        public void RemovePartialMessagesSubscription(string topicId)
+        {
+            _partialMessagesSubscriptions.TryRemove(topicId, out _);
+        }
+
+        public bool RequestsPartialMessages(string topicId)
+        {
+            return _partialMessagesSubscriptions.TryGetValue(topicId, out PartialMessagesSubscription subscription) && subscription.RequestsPartialMessages;
+        }
+
+        public bool SupportsSendingPartialMessages(string topicId)
+        {
+            return _partialMessagesSubscriptions.TryGetValue(topicId, out PartialMessagesSubscription subscription) && subscription.SupportsSendingPartialMessages;
+        }
+
+        private Rpc AddExtensionsIfNeeded(Rpc rpc)
+        {
+            if (!_advertisesPartialMessages || !SupportsExtensions || ExtensionsSent)
+            {
+                return rpc;
+            }
+
+            lock (_extensionsLock)
+            {
+                if (ExtensionsSent)
+                {
+                    return rpc;
+                }
+
+                Rpc extendedRpc = rpc.Clone();
+                extendedRpc.Control ??= new ControlMessage();
+                extendedRpc.Control.Extensions ??= new ControlExtensions();
+                extendedRpc.Control.Extensions.PartialMessages = true;
+                ExtensionsSent = true;
+                return extendedRpc;
+            }
+        }
 
         public Action<Rpc>? SendRpc
         {
@@ -130,6 +194,17 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     #endregion
 
     public event Action<string, PeerId, byte[]>? OnMessage;
+    /// <summary>
+    /// Raised for Gossipsub v1.3 Partial Messages extension payloads. The router
+    /// does not retain their application-defined state.
+    /// </summary>
+    public event Action<string, PeerId, PartialMessage>? OnPartialMessage;
+
+    /// <summary>
+    /// Raised with non-mesh peers that requested partial messages instead of an
+    /// IHAVE announcement. Applications can respond by calling <see cref="SendPartial"/>.
+    /// </summary>
+    public event Action<string, IReadOnlyList<PeerId>>? OnPartialGossip;
     public Func<Message, MessageValidity>? VerifyMessage = null;
 
     internal int MaxRpcBytes => _settings.MaxRpcBytes;
@@ -311,6 +386,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         DecayScores();
 
         ConcurrentDictionary<PeerId, Rpc> peerMessages = new();
+        List<(string Topic, PeerId[] Peers)> partialGossipNotifications = [];
+        Action<string, IReadOnlyList<PeerId>>? onPartialGossip = OnPartialGossip;
         lock (this)
         {
             // First, prune peers with negative scores from all meshes (Gossipsub v1.1)
@@ -449,15 +526,35 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     // Only send gossip to peers above gossip threshold
                     HashSet<PeerId>? topicMesh = mesh.GetValueOrDefault(topic);
                     HashSet<PeerId>? topicFanout = fanout.GetValueOrDefault(topic);
-                    var eligiblePeers = topicGossipsubPeers
+                    PeerId[] eligiblePeers = topicGossipsubPeers
                         .Where(p => !(topicMesh?.Contains(p) ?? false)
                             && !(topicFanout?.Contains(p) ?? false)
-                            && GetPeerScore(p) >= _settings.GossipThreshold);
+                            && GetPeerScore(p) >= _settings.GossipThreshold)
+                        .ToArray();
 
                     // Adaptive gossip: send to gossip_factor of eligible peers (min D_lazy)
-                    int gossipCount = Math.Max(_settings.LazyDegree, (int)(eligiblePeers.Count() * _settings.GossipFactor));
+                    int gossipCount = Math.Max(_settings.LazyDegree, (int)(eligiblePeers.Length * _settings.GossipFactor));
+                    PeerId[] gossipPeers = eligiblePeers.Take(gossipCount).ToArray();
 
-                    foreach (PeerId? peer in eligiblePeers.Take(gossipCount))
+                    if (onPartialGossip is not null &&
+                        _settings.EnablePartialMessages &&
+                        topicState.TryGetValue(topic, out Topic? localTopic) &&
+                        localTopic.SupportsSendingPartialMessages)
+                    {
+                        PeerId[] partialGossipPeers = gossipPeers
+                            .Where(peerId => peerState.TryGetValue(peerId, out PubsubPeer? peer) &&
+                                peer.SupportsPartialMessagesExtension &&
+                                peer.RequestsPartialMessages(topic))
+                            .ToArray();
+
+                        if (partialGossipPeers.Length > 0)
+                        {
+                            partialGossipNotifications.Add((topic, partialGossipPeers));
+                            gossipPeers = gossipPeers.Except(partialGossipPeers).ToArray();
+                        }
+                    }
+
+                    foreach (PeerId peer in gossipPeers)
                     {
                         peerMessages.GetOrAdd(peer, _ => new Rpc())
                             .Ensure(r => r.Control.Ihave).Add(ihave);
@@ -469,6 +566,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         foreach (KeyValuePair<PeerId, Rpc> peerMessage in peerMessages)
         {
             peerState.GetValueOrDefault(peerMessage.Key)?.Send(peerMessage.Value);
+        }
+
+        foreach ((string topic, PeerId[] peers) in partialGossipNotifications)
+        {
+            onPartialGossip?.Invoke(topic, peers);
         }
 
         return Task.CompletedTask;
@@ -535,11 +637,12 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     .ToArray();
             }
 
-            if (topics.Any())
+            if (topics.Any() || peer.NeedsExtensions)
             {
                 logger?.LogDebug("Topics sent to {peerId}: {topics}", peerId, string.Join(",", topics));
 
-                Rpc helloMessage = new Rpc().WithTopics(topics, []);
+                Rpc helloMessage = new();
+                helloMessage.Subscriptions.AddRange(topics.Select(topic => CreateSubscription(topic, subscribe: true)));
                 peer.Send(helloMessage);
             }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -33,7 +33,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     public const string GossipsubProtocolVersionV12 = "/meshsub/1.2.0";
     public const string GossipsubProtocolVersionV13 = "/meshsub/1.3.0";
 
-    class PubsubPeer
+    internal sealed class PubsubPeer
     {
         public PubsubPeer(PeerId peerId, string protocolId, ILogger? logger, PubsubSettings settings)
         {
@@ -67,16 +67,16 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
         public void Send(Rpc rpc)
         {
-            rpc = RemoveUnsupportedPartialSubscriptionOptions(rpc);
-            rpc = AddExtensionsIfNeeded(rpc);
-            SendRpcQueue.Enqueue(rpc);
-            if (SendRpc is not null)
+            lock (SendRpcQueue)
             {
-                lock (SendRpcQueue)
+                rpc = RemoveUnsupportedPartialSubscriptionOptions(rpc);
+                rpc = AddExtensionsIfNeeded(rpc);
+                SendRpcQueue.Enqueue(rpc);
+                if (_sendRpc is not null)
                 {
                     while (SendRpcQueue.TryDequeue(out Rpc? rpcToSend))
                     {
-                        SendRpc.Invoke(rpcToSend);
+                        _sendRpc.Invoke(rpcToSend);
                     }
                 }
             }
@@ -104,7 +104,6 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         private Action<Rpc>? _sendRpc;
         private readonly ILogger? _logger;
         private readonly bool _advertisesPartialMessages;
-        private readonly object _extensionsLock = new();
         private readonly ConcurrentDictionary<string, PartialMessagesSubscription> _partialMessagesSubscriptions = new();
 
         private readonly record struct PartialMessagesSubscription(bool RequestsPartialMessages, bool SupportsSendingPartialMessages);
@@ -117,7 +116,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         {
             get
             {
-                lock (_extensionsLock)
+                lock (SendRpcQueue)
                 {
                     return _advertisesPartialMessages && SupportsExtensions && !ExtensionsSent;
                 }
@@ -151,36 +150,34 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 return rpc;
             }
 
-            lock (_extensionsLock)
-            {
-                if (ExtensionsSent)
-                {
-                    return rpc;
-                }
-
-                Rpc extendedRpc = rpc.Clone();
-                extendedRpc.Control ??= new ControlMessage();
-                extendedRpc.Control.Extensions ??= new ControlExtensions();
-                extendedRpc.Control.Extensions.PartialMessages = true;
-                ExtensionsSent = true;
-                return extendedRpc;
-            }
+            Rpc extendedRpc = rpc.Clone();
+            extendedRpc.Control ??= new ControlMessage();
+            extendedRpc.Control.Extensions ??= new ControlExtensions();
+            extendedRpc.Control.Extensions.PartialMessages = true;
+            ExtensionsSent = true;
+            return extendedRpc;
         }
 
         public Action<Rpc>? SendRpc
         {
-            get => _sendRpc; set
+            get
             {
-                _logger?.LogDebug($"Set SENDRPC for {PeerId}: {value}");
-                _sendRpc = value;
-                if (_sendRpc is not null)
-                    lock (SendRpcQueue)
+                lock (SendRpcQueue)
+                {
+                    return _sendRpc;
+                }
+            }
+            set
+            {
+                lock (SendRpcQueue)
+                {
+                    _logger?.LogDebug($"Set SENDRPC for {PeerId}: {value}");
+                    _sendRpc = value;
+                    while (_sendRpc is not null && SendRpcQueue.TryDequeue(out Rpc? rpcToSend))
                     {
-                        while (SendRpcQueue.TryDequeue(out Rpc? rpcToSend))
-                        {
-                            _sendRpc.Invoke(rpcToSend);
-                        }
+                        _sendRpc.Invoke(rpcToSend);
                     }
+                }
             }
         }
         public CancellationTokenSource TokenSource { get; init; }
@@ -220,10 +217,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     public event Action<string, PeerId, PartialMessage>? OnPartialMessage;
 
     /// <summary>
-    /// Raised with non-mesh peers that requested partial messages instead of an
-    /// IHAVE announcement. Applications can respond by calling <see cref="SendPartial"/>.
+    /// Raised with a locally published partial-message group and non-mesh peers
+    /// that requested it instead of an IHAVE announcement. Applications can
+    /// respond by calling <see cref="SendPartial"/> for the supplied group.
     /// </summary>
-    public event Action<string, IReadOnlyList<PeerId>>? OnPartialGossip;
+    public event Action<string, byte[], IReadOnlyList<PeerId>>? OnPartialGossip;
     public Func<Message, MessageValidity>? VerifyMessage = null;
 
     internal int MaxRpcBytes => _settings.MaxRpcBytes;
@@ -232,6 +230,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     private readonly TtlCache<MessageId, MessageWithId> _messageCache;
     private readonly TtlCache<MessageId, MessageWithId> _limboMessageCache;
     private readonly TtlCache<(PeerId, MessageId)> _idontwantMessages;
+    private readonly PartialMessageGossipCache partialMessageGossip;
 
     private ILocalPeer? localPeer;
     private readonly ILogger? logger;
@@ -279,6 +278,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         _messageCache = new(_settings.MessageCacheTtl);
         _limboMessageCache = new(_settings.MessageCacheTtl);
         _idontwantMessages = new(_settings.MessageCacheTtl);
+        partialMessageGossip = new(_settings.MaxPartialMessageGroupsPerTopic, _settings.PartialMessageGossipTtlHeartbeats);
     }
 
     public Task StartAsync(ILocalPeer localPeer, CancellationToken token = default)
@@ -405,8 +405,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         DecayScores();
 
         ConcurrentDictionary<PeerId, Rpc> peerMessages = new();
-        List<(string Topic, PeerId[] Peers)> partialGossipNotifications = [];
-        Action<string, IReadOnlyList<PeerId>>? onPartialGossip = OnPartialGossip;
+        List<(string Topic, byte[] GroupId, PeerId[] Peers)> partialGossipNotifications = [];
+        Action<string, byte[], IReadOnlyList<PeerId>>? onPartialGossip = OnPartialGossip;
         lock (this)
         {
             // First, prune peers with negative scores from all meshes (Gossipsub v1.1)
@@ -537,42 +537,56 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 .ToArray())
             {
                 IGrouping<string, MessageWithId>? msgsInTopic = msgs.FirstOrDefault(mit => mit.Key == topic);
-                if (msgsInTopic is not null && gPeers.TryGetValue(topic, out HashSet<PeerId>? topicGossipsubPeers))
+                bool canGossipPartialMessages =
+                    onPartialGossip is not null &&
+                    _settings.EnablePartialMessages &&
+                    topicState.TryGetValue(topic, out Topic? localTopic) &&
+                    localTopic.SupportsSendingPartialMessages;
+                IReadOnlyList<byte[]> partialMessageGroupIds = canGossipPartialMessages
+                    ? partialMessageGossip.GetGroupIds(topic)
+                    : [];
+                if (msgsInTopic is null && partialMessageGroupIds.Count == 0)
+                {
+                    continue;
+                }
+
+                // Only send gossip to peers above gossip threshold.
+                HashSet<PeerId> fanoutPeers = fanout.GetValueOrDefault(topic) ?? [];
+                HashSet<PeerId> topicMesh = mesh.GetValueOrDefault(topic) ?? [];
+                HashSet<PeerId> topicGossipsubPeers = gPeers.GetValueOrDefault(topic) ?? [];
+                PeerId[] eligiblePeers = topicGossipsubPeers
+                    .Where(p => !topicMesh.Contains(p)
+                        && !fanoutPeers.Contains(p)
+                        && GetPeerScore(p) >= _settings.GossipThreshold)
+                    .ToArray();
+
+                // Adaptive gossip: send to gossip_factor of eligible peers (min D_lazy).
+                int gossipCount = Math.Max(_settings.LazyDegree, (int)(eligiblePeers.Length * _settings.GossipFactor));
+                PeerId[] gossipPeers = eligiblePeers.Take(gossipCount).ToArray();
+
+                if (partialMessageGroupIds.Count > 0)
+                {
+                    PeerId[] partialGossipPeers = gossipPeers
+                        .Where(peerId => peerState.TryGetValue(peerId, out PubsubPeer? peer) &&
+                            peer.SupportsPartialMessagesExtension &&
+                            peer.RequestsPartialMessages(topic))
+                        .ToArray();
+
+                    if (partialGossipPeers.Length > 0)
+                    {
+                        foreach (byte[] groupId in partialMessageGroupIds)
+                        {
+                            partialGossipNotifications.Add((topic, groupId, partialGossipPeers));
+                        }
+
+                        gossipPeers = gossipPeers.Except(partialGossipPeers).ToArray();
+                    }
+                }
+
+                if (msgsInTopic is not null)
                 {
                     ControlIHave ihave = new() { TopicID = topic };
                     ihave.MessageIDs.AddRange(msgsInTopic.Select(m => ByteString.CopyFrom(m.Id.Bytes)));
-
-                    // Only send gossip to peers above gossip threshold
-                    HashSet<PeerId>? topicMesh = mesh.GetValueOrDefault(topic);
-                    HashSet<PeerId>? topicFanout = fanout.GetValueOrDefault(topic);
-                    PeerId[] eligiblePeers = topicGossipsubPeers
-                        .Where(p => !(topicMesh?.Contains(p) ?? false)
-                            && !(topicFanout?.Contains(p) ?? false)
-                            && GetPeerScore(p) >= _settings.GossipThreshold)
-                        .ToArray();
-
-                    // Adaptive gossip: send to gossip_factor of eligible peers (min D_lazy)
-                    int gossipCount = Math.Max(_settings.LazyDegree, (int)(eligiblePeers.Length * _settings.GossipFactor));
-                    PeerId[] gossipPeers = eligiblePeers.Take(gossipCount).ToArray();
-
-                    if (onPartialGossip is not null &&
-                        _settings.EnablePartialMessages &&
-                        topicState.TryGetValue(topic, out Topic? localTopic) &&
-                        localTopic.SupportsSendingPartialMessages)
-                    {
-                        PeerId[] partialGossipPeers = gossipPeers
-                            .Where(peerId => peerState.TryGetValue(peerId, out PubsubPeer? peer) &&
-                                peer.SupportsPartialMessagesExtension &&
-                                peer.RequestsPartialMessages(topic))
-                            .ToArray();
-
-                        if (partialGossipPeers.Length > 0)
-                        {
-                            partialGossipNotifications.Add((topic, partialGossipPeers));
-                            gossipPeers = gossipPeers.Except(partialGossipPeers).ToArray();
-                        }
-                    }
-
                     foreach (PeerId peer in gossipPeers)
                     {
                         peerMessages.GetOrAdd(peer, _ => new Rpc())
@@ -580,6 +594,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     }
                 }
             }
+
+            partialMessageGossip.Heartbeat();
         }
 
         foreach (KeyValuePair<PeerId, Rpc> peerMessage in peerMessages)
@@ -587,9 +603,9 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             peerState.GetValueOrDefault(peerMessage.Key)?.Send(peerMessage.Value);
         }
 
-        foreach ((string topic, PeerId[] peers) in partialGossipNotifications)
+        foreach ((string topic, byte[] groupId, PeerId[] peers) in partialGossipNotifications)
         {
-            onPartialGossip?.Invoke(topic, peers);
+            onPartialGossip?.Invoke(topic, groupId, peers);
         }
 
         return Task.CompletedTask;

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -67,6 +67,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
         public void Send(Rpc rpc)
         {
+            rpc = RemoveUnsupportedPartialSubscriptionOptions(rpc);
             rpc = AddExtensionsIfNeeded(rpc);
             SendRpcQueue.Enqueue(rpc);
             if (SendRpc is not null)
@@ -80,6 +81,24 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 }
             }
         }
+
+        private Rpc RemoveUnsupportedPartialSubscriptionOptions(Rpc rpc)
+        {
+            if (SupportsExtensions || !rpc.Subscriptions.Any(subscription => subscription.HasRequestsPartial || subscription.HasSupportsSendingPartial))
+            {
+                return rpc;
+            }
+
+            Rpc filteredRpc = rpc.Clone();
+            foreach (Rpc.Types.SubOpts subscription in filteredRpc.Subscriptions)
+            {
+                subscription.ClearRequestsPartial();
+                subscription.ClearSupportsSendingPartial();
+            }
+
+            return filteredRpc;
+        }
+
         public Dictionary<string, DateTime> Backoff { get; internal set; }
         public ConcurrentQueue<Rpc> SendRpcQueue { get; }
         private Action<Rpc>? _sendRpc;

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
@@ -55,13 +55,13 @@ internal class Topic : IPartialMessagesTopic
     internal void ConfigurePartialMessages(PartialMessagesTopicOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
-        if (options.RequestPartialMessages && !options.SupportSendingPartialMessages)
+        if (options.RequestPartialMessages && !options.SupportsSendingPartialMessages)
         {
             throw new ArgumentException("Requesting partial messages requires support for sending partial messages.", nameof(options));
         }
 
         RequestsPartialMessages = options.RequestPartialMessages;
-        SupportsSendingPartialMessages = options.SupportSendingPartialMessages;
+        SupportsSendingPartialMessages = options.SupportsSendingPartialMessages;
     }
 
     public void Publish(byte[] value)

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
@@ -5,17 +5,17 @@ using Nethermind.Libp2p.Core;
 
 namespace Nethermind.Libp2p.Protocols.Pubsub;
 
-internal class Topic : IPartialMessagesTopic
+internal class Topic : ITopic
 {
     private readonly PubsubRouter router;
     private readonly string topicName;
+    private PartialMessagesTopic? partialMessagesTopic;
 
     public Topic(PubsubRouter router, string topicName)
     {
         this.router = router;
         this.topicName = topicName;
         router.OnMessage += OnRouterMessage;
-        router.OnPartialMessage += OnRouterPartialMessage;
     }
 
     private void OnRouterMessage(string topicName, PeerId peerId, byte[] message)
@@ -32,27 +32,17 @@ internal class Topic : IPartialMessagesTopic
         }
     }
 
-    private void OnRouterPartialMessage(string topicName, PeerId peerId, PartialMessage message)
-    {
-        if (this.topicName != topicName)
-        {
-            return;
-        }
-
-        Action<PeerId, PartialMessage>? onPartialMessage = OnPartialMessage;
-        onPartialMessage?.Invoke(peerId, message);
-    }
-
     public DateTime LastPublished { get; set; }
 
     public bool IsSubscribed { get; internal set; }
-    public bool RequestsPartialMessages { get; private set; }
-    public bool SupportsSendingPartialMessages { get; private set; }
+    internal bool RequestsPartialMessages { get; private set; }
+    internal bool SupportsSendingPartialMessages { get; private set; }
+    internal PubsubRouter Router => router;
+    internal string Name => topicName;
 
     public event Action<PeerId, byte[]>? OnMessage;
-    public event Action<PeerId, PartialMessage>? OnPartialMessage;
 
-    internal void ConfigurePartialMessages(PartialMessagesTopicOptions options)
+    internal IPartialMessagesTopic ConfigurePartialMessages(PartialMessagesTopicOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
         if (options.RequestPartialMessages && !options.SupportsSendingPartialMessages)
@@ -62,21 +52,12 @@ internal class Topic : IPartialMessagesTopic
 
         RequestsPartialMessages = options.RequestPartialMessages;
         SupportsSendingPartialMessages = options.SupportsSendingPartialMessages;
+        return partialMessagesTopic ??= new PartialMessagesTopic(this);
     }
 
     public void Publish(byte[] value)
     {
         router.Publish(topicName, value);
-    }
-
-    public void PublishPartial(byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null)
-    {
-        router.PublishPartial(topicName, groupId, partialMessage, partsMetadata);
-    }
-
-    public void SendPartial(PeerId peerId, byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null)
-    {
-        router.SendPartial(peerId, topicName, groupId, partialMessage, partsMetadata);
     }
 
     public void Unsubscribe()
@@ -87,5 +68,54 @@ internal class Topic : IPartialMessagesTopic
     public void Subscribe()
     {
         if (!IsSubscribed) router.Subscribe(topicName);
+    }
+}
+
+internal sealed class PartialMessagesTopic : IPartialMessagesTopic
+{
+    private readonly Topic topic;
+
+    public PartialMessagesTopic(Topic topic)
+    {
+        this.topic = topic;
+        topic.Router.OnPartialMessage += OnRouterPartialMessage;
+    }
+
+    public event Action<PeerId, byte[]>? OnMessage
+    {
+        add => topic.OnMessage += value;
+        remove => topic.OnMessage -= value;
+    }
+
+    public event Action<PeerId, PartialMessage>? OnPartialMessage;
+
+    public bool IsSubscribed => topic.IsSubscribed;
+    public bool RequestsPartialMessages => topic.RequestsPartialMessages;
+    public bool SupportsSendingPartialMessages => topic.SupportsSendingPartialMessages;
+
+    public void Publish(byte[] value) => topic.Publish(value);
+
+    public void PublishPartial(byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null)
+    {
+        topic.Router.PublishPartial(topic.Name, groupId, partialMessage, partsMetadata);
+    }
+
+    public void SendPartial(PeerId peerId, byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null)
+    {
+        topic.Router.SendPartial(peerId, topic.Name, groupId, partialMessage, partsMetadata);
+    }
+
+    public void Unsubscribe() => topic.Unsubscribe();
+
+    public void Subscribe() => topic.Subscribe();
+
+    private void OnRouterPartialMessage(string topicName, PeerId peerId, PartialMessage message)
+    {
+        if (topic.Name != topicName)
+        {
+            return;
+        }
+
+        OnPartialMessage?.Invoke(peerId, message);
     }
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/Topic.cs
@@ -5,7 +5,7 @@ using Nethermind.Libp2p.Core;
 
 namespace Nethermind.Libp2p.Protocols.Pubsub;
 
-internal class Topic : ITopic
+internal class Topic : IPartialMessagesTopic
 {
     private readonly PubsubRouter router;
     private readonly string topicName;
@@ -15,6 +15,7 @@ internal class Topic : ITopic
         this.router = router;
         this.topicName = topicName;
         router.OnMessage += OnRouterMessage;
+        router.OnPartialMessage += OnRouterPartialMessage;
     }
 
     private void OnRouterMessage(string topicName, PeerId peerId, byte[] message)
@@ -31,15 +32,51 @@ internal class Topic : ITopic
         }
     }
 
+    private void OnRouterPartialMessage(string topicName, PeerId peerId, PartialMessage message)
+    {
+        if (this.topicName != topicName)
+        {
+            return;
+        }
+
+        Action<PeerId, PartialMessage>? onPartialMessage = OnPartialMessage;
+        onPartialMessage?.Invoke(peerId, message);
+    }
+
     public DateTime LastPublished { get; set; }
 
     public bool IsSubscribed { get; internal set; }
+    public bool RequestsPartialMessages { get; private set; }
+    public bool SupportsSendingPartialMessages { get; private set; }
 
     public event Action<PeerId, byte[]>? OnMessage;
+    public event Action<PeerId, PartialMessage>? OnPartialMessage;
+
+    internal void ConfigurePartialMessages(PartialMessagesTopicOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.RequestPartialMessages && !options.SupportSendingPartialMessages)
+        {
+            throw new ArgumentException("Requesting partial messages requires support for sending partial messages.", nameof(options));
+        }
+
+        RequestsPartialMessages = options.RequestPartialMessages;
+        SupportsSendingPartialMessages = options.SupportSendingPartialMessages;
+    }
 
     public void Publish(byte[] value)
     {
         router.Publish(topicName, value);
+    }
+
+    public void PublishPartial(byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null)
+    {
+        router.PublishPartial(topicName, groupId, partialMessage, partsMetadata);
+    }
+
+    public void SendPartial(PeerId peerId, byte[] groupId, byte[]? partialMessage = null, byte[]? partsMetadata = null)
+    {
+        router.SendPartial(peerId, topicName, groupId, partialMessage, partsMetadata);
     }
 
     public void Unsubscribe()


### PR DESCRIPTION
## Summary
- provide an opt-in application API for the Gossipsub v1.3 Partial Messages extension
- advertise capabilities only on v1.3 streams and honor each peer's subscription flags
- forward application-defined partial payloads without retaining peer-initiated state
- replace eligible IHAVE gossip with application callbacks for partial-message recipients

## Validation
- Pubsub protocol unit tests