### PR TITLE
Add Gossipsub direct peer support

### DIFF
--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/DirectPeersTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/DirectPeersTests.cs
@@ -155,6 +155,7 @@ public class DirectPeersTests
             DirectPeers = new[] { Multiaddress.Decode("/ip4/127.0.0.1/tcp/4001") },
         };
 
-        Assert.That(() => new PubsubRouter(new PeerStore(), settings), Throws.TypeOf<ArgumentException>());
+        ArgumentException exception = Assert.Throws<ArgumentException>(() => new PubsubRouter(new PeerStore(), settings))!;
+        Assert.That(exception.ParamName, Is.EqualTo(nameof(PubsubSettings.DirectPeers)));
     }
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/DirectPeersTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/DirectPeersTests.cs
@@ -63,7 +63,7 @@ public class DirectPeersTests
         Multiaddress secondMeshAddress = TestPeers.Multiaddr(3);
         PubsubRouter router = new(
             new PeerStore(),
-            new PubsubSettings { DirectPeers = [directAddress] });
+            new PubsubSettings { DirectPeers = [directAddress], PruneBackoff = 2_000 });
         IRoutingStateContainer state = router;
         _ = router.GetTopic(topic);
         TaskCompletionSource connection = new();
@@ -105,7 +105,12 @@ public class DirectPeersTests
         graft.Control.Graft.Add(new ControlGraft { TopicID = topic });
         router.OnRpc(directPeerId, graft);
 
-        Assert.That(sentRpcs.Single().Control.Prune.Single().TopicID, Is.EqualTo(topic));
+        ControlPrune prune = sentRpcs.Single().Control.Prune.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(prune.TopicID, Is.EqualTo(topic));
+            Assert.That(prune.Backoff, Is.EqualTo(2));
+        });
         connection.SetResult();
     }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/DirectPeersTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/DirectPeersTests.cs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Multiformats.Address;
+using Nethermind.Libp2p.Core.Discovery;
+using Nethermind.Libp2p.Protocols;
+using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+using System.Collections.ObjectModel;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
+
+[TestFixture]
+public class DirectPeersTests
+{
+    [Test]
+    public void DirectPeers_ForwardValidMessagesDespitePeerScores()
+    {
+        const string topic = "topic";
+        Multiaddress senderAddress = TestPeers.Multiaddr(1);
+        Multiaddress receiverAddress = TestPeers.Multiaddr(2);
+        PeerId senderPeerId = senderAddress.GetPeerId()!;
+        PeerId receiverPeerId = receiverAddress.GetPeerId()!;
+        PubsubRouter router = new(
+            new PeerStore(),
+            new PubsubSettings { DirectPeers = [senderAddress, receiverAddress] });
+        ITopic localTopic = router.GetTopic(topic);
+        List<Rpc> senderRpcs = [];
+        List<Rpc> receiverRpcs = [];
+        TaskCompletionSource senderConnection = new();
+        TaskCompletionSource receiverConnection = new();
+        router.OutboundConnection(senderAddress, PubsubRouter.GossipsubProtocolVersionV11, senderConnection.Task, senderRpcs.Add);
+        router.OutboundConnection(receiverAddress, PubsubRouter.GossipsubProtocolVersionV11, receiverConnection.Task, receiverRpcs.Add);
+        router.OnRpc(senderPeerId, new Rpc().WithTopics([topic], []));
+        router.OnRpc(receiverPeerId, new Rpc().WithTopics([topic], []));
+
+        router.SetAppSpecificScore(senderPeerId, -20);
+        router.SetAppSpecificScore(receiverPeerId, -20);
+        senderRpcs.Clear();
+        receiverRpcs.Clear();
+
+        PeerId? receivedFrom = null;
+        localTopic.OnMessage += (peerId, _) => receivedFrom = peerId;
+        Identity author = TestPeers.Identity(1);
+        router.OnRpc(senderPeerId, new Rpc().WithMessages(topic, 1, author.PeerId.Bytes, [1, 2, 3], author));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(receivedFrom, Is.EqualTo(senderPeerId));
+            Assert.That(receiverRpcs.Single().Publish.Single().Data.ToByteArray(), Is.EqualTo(new byte[] { 1, 2, 3 }));
+            Assert.That(senderRpcs, Is.Empty);
+        });
+
+        senderConnection.SetResult();
+        receiverConnection.SetResult();
+    }
+
+    [Test]
+    public void DirectPeers_AreNeverAddedToTheMesh()
+    {
+        const string topic = "topic";
+        Multiaddress directAddress = TestPeers.Multiaddr(1);
+        Multiaddress firstMeshAddress = TestPeers.Multiaddr(2);
+        Multiaddress secondMeshAddress = TestPeers.Multiaddr(3);
+        PubsubRouter router = new(
+            new PeerStore(),
+            new PubsubSettings { DirectPeers = [directAddress] });
+        IRoutingStateContainer state = router;
+        _ = router.GetTopic(topic);
+        TaskCompletionSource connection = new();
+
+        foreach (Multiaddress address in new[] { directAddress, firstMeshAddress, secondMeshAddress })
+        {
+            router.OutboundConnection(address, PubsubRouter.GossipsubProtocolVersionV11, connection.Task, _ => { });
+            router.OnRpc(address.GetPeerId()!, new Rpc().WithTopics([topic], []));
+        }
+
+        router.Heartbeat().GetAwaiter().GetResult();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.GossipsubPeers[topic], Has.Member(directAddress.GetPeerId()));
+            Assert.That(state.Mesh[topic], Does.Not.Contain(directAddress.GetPeerId()));
+            Assert.That(state.Mesh[topic], Has.Count.EqualTo(2));
+        });
+
+        connection.SetResult();
+    }
+
+    [Test]
+    public void DirectPeerGrafts_AreRejectedWithPrune()
+    {
+        const string topic = "topic";
+        Multiaddress directAddress = TestPeers.Multiaddr(1);
+        PeerId directPeerId = directAddress.GetPeerId()!;
+        PubsubRouter router = new(
+            new PeerStore(),
+            new PubsubSettings { DirectPeers = [directAddress] });
+        _ = router.GetTopic(topic);
+        List<Rpc> sentRpcs = [];
+        TaskCompletionSource connection = new();
+        router.OutboundConnection(directAddress, PubsubRouter.GossipsubProtocolVersionV11, connection.Task, sentRpcs.Add);
+        sentRpcs.Clear();
+
+        Rpc graft = new() { Control = new ControlMessage() };
+        graft.Control.Graft.Add(new ControlGraft { TopicID = topic });
+        router.OnRpc(directPeerId, graft);
+
+        Assert.That(sentRpcs.Single().Control.Prune.Single().TopicID, Is.EqualTo(topic));
+        connection.SetResult();
+    }
+
+    [Test]
+    public async Task Router_ConnectsConfiguredDirectPeersAtStartup()
+    {
+        PeerStore peerStore = new();
+        Multiaddress directAddress = TestPeers.Multiaddr(1);
+        PeerId directPeerId = directAddress.GetPeerId()!;
+        peerStore.GetPeerInfo(directPeerId).SupportedProtocols = [PubsubRouter.GossipsubProtocolVersionV12];
+        PubsubRouter router = new(peerStore, new PubsubSettings { DirectPeers = [directAddress] });
+
+        TaskCompletionSource protocolDialed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        ISession session = Substitute.For<ISession>();
+        session.RemoteAddress.Returns(directAddress);
+        session.DialAsync<GossipsubProtocolV12>(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            protocolDialed.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        ILocalPeer localPeer = Substitute.For<ILocalPeer>();
+        localPeer.Identity.Returns(TestPeers.Identity(2));
+        localPeer.ListenAddresses.Returns(new ObservableCollection<Multiaddress>());
+        localPeer.DialAsync(Arg.Any<Multiaddress[]>(), Arg.Any<CancellationToken>()).Returns(session);
+
+        using CancellationTokenSource cancellation = new();
+        await router.StartAsync(localPeer, cancellation.Token);
+
+        await protocolDialed.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        _ = localPeer.Received(1).DialAsync(Arg.Any<Multiaddress[]>(), Arg.Any<CancellationToken>());
+        _ = session.Received(1).DialAsync<GossipsubProtocolV12>(Arg.Any<CancellationToken>());
+
+        cancellation.Cancel();
+    }
+
+    [Test]
+    public void DirectPeers_RequirePeerIdsInTheirAddresses()
+    {
+        PubsubSettings settings = new()
+        {
+            DirectPeers = new[] { Multiaddress.Decode("/ip4/127.0.0.1/tcp/4001") },
+        };
+
+        Assert.That(() => new PubsubRouter(new PeerStore(), settings), Throws.TypeOf<ArgumentException>());
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/DirectPeersTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/DirectPeersTests.cs
@@ -63,7 +63,7 @@ public class DirectPeersTests
         Multiaddress secondMeshAddress = TestPeers.Multiaddr(3);
         PubsubRouter router = new(
             new PeerStore(),
-            new PubsubSettings { DirectPeers = [directAddress], PruneBackoff = 2_000 });
+            new PubsubSettings { DirectPeers = [directAddress] });
         IRoutingStateContainer state = router;
         _ = router.GetTopic(topic);
         TaskCompletionSource connection = new();
@@ -94,7 +94,7 @@ public class DirectPeersTests
         PeerId directPeerId = directAddress.GetPeerId()!;
         PubsubRouter router = new(
             new PeerStore(),
-            new PubsubSettings { DirectPeers = [directAddress] });
+            new PubsubSettings { DirectPeers = [directAddress], PruneBackoff = 2_000 });
         _ = router.GetTopic(topic);
         List<Rpc> sentRpcs = [];
         TaskCompletionSource connection = new();

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/PubsubProtocolTests.cs
@@ -40,6 +40,18 @@ public class PubsubProtocolTests
     }
 
     [Test]
+    public async Task Publish_WithoutSubscription_DoesNotThrow()
+    {
+        PubsubRouter router = new(new PeerStore());
+        using CancellationTokenSource cancellation = new();
+        await router.StartAsync(new LocalPeerStub(), cancellation.Token);
+
+        Assert.DoesNotThrow(() => router.Publish("test-topic", [1, 2, 3]));
+
+        cancellation.Cancel();
+    }
+
+    [Test]
     public void Topic_OnMessage_IncludesReceivedFromPeerId()
     {
         PeerStore peerStore = new();

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Libp2p.Core;
 using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+using Multiformats.Address;
 
 namespace Nethermind.Libp2p.Protocols.Pubsub;
 
@@ -21,6 +22,18 @@ public class PubsubSettings
     public int LazyDegree { get; set; } = 6; // (Optional) the outbound degree for gossip emission D
 
     public int MaxConnections { get; set; }
+
+    /// <summary>
+    /// Peers with reciprocal explicit peering agreements. Each address must
+    /// contain a peer ID and is configured before the router starts.
+    /// </summary>
+    public Multiaddress[] DirectPeers { get; set; } = [];
+
+    /// <summary>
+    /// Interval for reconnecting disconnected direct peers. Gossipsub recommends
+    /// five minutes.
+    /// </summary>
+    public int DirectConnectPeriod { get; set; } = 5 * 60 * 1000;
 
     public int HeartbeatInterval { get; set; } = 1_000; // Time between heartbeats 	1 second
     public int FanoutTtl { get; set; } = 60 * 1000; // Time-to-live for each topic's fanout state 	60 seconds

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -333,7 +333,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 logger?.LogWarning("Rejecting GRAFT from direct peer {peerId} for topic {topic}", peerId, graft.TopicID);
                 peerMessages.GetOrAdd(peerId, _ => new Rpc())
                     .Ensure(r => r.Control.Prune)
-                    .Add(new ControlPrune { TopicID = graft.TopicID });
+                    .Add(new ControlPrune { TopicID = graft.TopicID, Backoff = (ulong)Math.Max(1, _settings.PruneBackoff / 1_000) });
                 continue;
             }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -159,7 +159,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     private void HandleNewMessages(PeerId peerId, IEnumerable<Message> messages, ConcurrentDictionary<PeerId, Rpc> peerMessages, List<(string Topic, PeerId PeerId, byte[] Data)> receivedMessages)
     {
         // Check if peer is graylisted (Gossipsub v1.1)
-        if (ShouldGraylistPeer(peerId))
+        if (!IsDirectPeer(peerId) && ShouldGraylistPeer(peerId))
         {
             logger?.LogDebug("Ignoring messages from graylisted peer {peerId}", peerId);
             return;
@@ -214,11 +214,19 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             PeerId author = new(message.From.ToArray());
             receivedMessages.Add((message.Topic, peerId, message.Data.ToByteArray()));
 
+            foreach (PeerId directPeerId in GetDirectPeersForTopic(message.Topic))
+            {
+                if (directPeerId != author && directPeerId != peerId && ShouldSendFullMessage(directPeerId, message.Topic))
+                {
+                    peerMessages.GetOrAdd(directPeerId, _ => new Rpc()).Publish.Add(message);
+                }
+            }
+
             if (fPeers.TryGetValue(message.Topic, out HashSet<PeerId>? topicPeers))
             {
                 foreach (PeerId peer in topicPeers)
                 {
-                    if (peer == author || peer == peerId)
+                    if (peer == author || peer == peerId || IsDirectPeer(peer))
                     {
                         continue;
                     }
@@ -232,7 +240,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             {
                 foreach (PeerId peer in topicPeers)
                 {
-                    if (peer == author || peer == peerId)
+                    if (peer == author || peer == peerId || IsDirectPeer(peer))
                     {
                         continue;
                     }
@@ -320,6 +328,15 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     {
         foreach (ControlGraft? graft in grafts)
         {
+            if (IsDirectPeer(peerId))
+            {
+                logger?.LogWarning("Rejecting GRAFT from direct peer {peerId} for topic {topic}", peerId, graft.TopicID);
+                peerMessages.GetOrAdd(peerId, _ => new Rpc())
+                    .Ensure(r => r.Control.Prune)
+                    .Add(new ControlPrune { TopicID = graft.TopicID });
+                continue;
+            }
+
             if (topicState.GetValueOrDefault(graft.TopicID)?.IsSubscribed is not true ||
                 !mesh.TryGetValue(graft.TopicID, out HashSet<PeerId>? topicMesh))
             {

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -192,10 +192,19 @@ public partial class PubsubRouter
             ulong seqNo = this.seqNo++;
             Rpc rpc = new Rpc().WithMessages(topicId, seqNo, localPeer.Identity.PeerId.Bytes, message, localPeer.Identity);
 
+            HashSet<PeerId> directRecipients = GetDirectPeersForTopic(topicId).ToHashSet();
+            foreach (PeerId peerId in directRecipients)
+            {
+                if (ShouldSendFullMessage(peerId, topicId))
+                {
+                    peerState.GetValueOrDefault(peerId)?.Send(rpc);
+                }
+            }
+
             // Floodsub peers always get the message.
             foreach (PeerId peerId in fPeers.GetValueOrDefault(topicId) ?? [])
             {
-                if (ShouldSendFullMessage(peerId, topicId))
+                if (!directRecipients.Contains(peerId) && ShouldSendFullMessage(peerId, topicId))
                 {
                     peerState.GetValueOrDefault(peerId)?.Send(rpc);
                 }
@@ -207,7 +216,9 @@ public partial class PubsubRouter
                 // Send to all gossipsub peers above publish threshold
                 foreach (PeerId peerId in allGossipsubPeers)
                 {
-                    if (GetPeerScore(peerId) >= _settings.PublishThreshold && ShouldSendFullMessage(peerId, topicId))
+                    if (!directRecipients.Contains(peerId) &&
+                        GetPeerScore(peerId) >= _settings.PublishThreshold &&
+                        ShouldSendFullMessage(peerId, topicId))
                     {
                         peerState.GetValueOrDefault(peerId)?.Send(rpc);
                     }
@@ -218,7 +229,9 @@ public partial class PubsubRouter
                 // Standard gossipsub v1.0 behavior: send to mesh or fanout
                 foreach (PeerId peerId in meshPeers)
                 {
-                    if (GetPeerScore(peerId) >= _settings.PublishThreshold && ShouldSendFullMessage(peerId, topicId))
+                    if (!directRecipients.Contains(peerId) &&
+                        GetPeerScore(peerId) >= _settings.PublishThreshold &&
+                        ShouldSendFullMessage(peerId, topicId))
                     {
                         peerState.GetValueOrDefault(peerId)?.Send(rpc);
                     }
@@ -235,7 +248,7 @@ public partial class PubsubRouter
                     if (topicPeers is { Count: > 0 })
                     {
                         // Select peers with non-negative scores
-                        var eligiblePeers = topicPeers.Where(p => GetPeerScore(p) >= 0).ToList();
+                        var eligiblePeers = topicPeers.Where(p => !IsDirectPeer(p) && GetPeerScore(p) >= 0).ToList();
                         foreach (PeerId peer in eligiblePeers.Take(_settings.Degree))
                         {
                             topicFanout.Add(peer);
@@ -245,7 +258,9 @@ public partial class PubsubRouter
 
                 foreach (PeerId peerId in topicFanout)
                 {
-                    if (GetPeerScore(peerId) >= _settings.PublishThreshold && ShouldSendFullMessage(peerId, topicId))
+                    if (!directRecipients.Contains(peerId) &&
+                        GetPeerScore(peerId) >= _settings.PublishThreshold &&
+                        ShouldSendFullMessage(peerId, topicId))
                     {
                         peerState.GetValueOrDefault(peerId)?.Send(rpc);
                     }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -279,7 +279,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
         if (_settings.DirectConnectPeriod <= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(settings), "DirectConnectPeriod must be positive.");
+            throw new ArgumentOutOfRangeException(nameof(PubsubSettings.DirectConnectPeriod), "DirectConnectPeriod must be positive.");
         }
 
         directPeers = CreateDirectPeers(_settings.DirectPeers);

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -253,6 +253,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
     private readonly ConcurrentBag<Reconnection> reconnections = [];
     private readonly PeerStore _peerStore;
+    private readonly IReadOnlyDictionary<PeerId, Multiaddress[]> directPeers;
+    private DateTime nextDirectConnectionAttempt;
     private ulong seqNo = 1;
 
     private record Reconnection(Multiaddress[] Addresses, int Attempts);
@@ -275,6 +277,12 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             throw new InvalidOperationException("StrictNoSign requires a custom GetMessageId function.");
         }
 
+        if (_settings.DirectConnectPeriod <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(settings), "DirectConnectPeriod must be positive.");
+        }
+
+        directPeers = CreateDirectPeers(_settings.DirectPeers);
         _messageCache = new(_settings.MessageCacheTtl);
         _limboMessageCache = new(_settings.MessageCacheTtl);
         _idontwantMessages = new(_settings.MessageCacheTtl);
@@ -300,6 +308,12 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             }
             _ = Connect(addrs, token, true);
         };
+
+        foreach (Multiaddress[] directPeerAddresses in directPeers.Values)
+        {
+            _peerStore.Discover(directPeerAddresses);
+        }
+        nextDirectConnectionAttempt = DateTime.UtcNow.AddMilliseconds(_settings.DirectConnectPeriod);
 
         _ = Task.Run(LoopHeartbeat, token);
         _ = Task.Run(LoopReconnect, token);
@@ -397,6 +411,46 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 }
             }, token);
         }
+
+        ReconnectDirectPeers(token);
+    }
+
+    private static IReadOnlyDictionary<PeerId, Multiaddress[]> CreateDirectPeers(IEnumerable<Multiaddress>? configuredPeers)
+    {
+        return (configuredPeers ?? [])
+            .Select(address => (PeerId: address.GetPeerId() ?? throw new ArgumentException("A direct peer address must include a peer ID.", nameof(configuredPeers)), Address: address))
+            .GroupBy(entry => entry.PeerId)
+            .ToDictionary(group => group.Key, group => group.Select(entry => entry.Address).ToArray());
+    }
+
+    private void ReconnectDirectPeers(CancellationToken token)
+    {
+        if (directPeers.Count == 0 || DateTime.UtcNow < nextDirectConnectionAttempt)
+        {
+            return;
+        }
+
+        nextDirectConnectionAttempt = DateTime.UtcNow.AddMilliseconds(_settings.DirectConnectPeriod);
+        foreach ((PeerId peerId, Multiaddress[] addresses) in directPeers)
+        {
+            if (!peerState.ContainsKey(peerId))
+            {
+                _ = Connect(addresses, token, reconnect: true);
+            }
+        }
+    }
+
+    private bool IsDirectPeer(PeerId peerId) => directPeers.ContainsKey(peerId);
+
+    private bool IsDirectPeerSubscribedTo(PeerId peerId, string topic)
+    {
+        return (fPeers.TryGetValue(topic, out HashSet<PeerId>? floodsubPeers) && floodsubPeers.Contains(peerId)) ||
+               (gPeers.TryGetValue(topic, out HashSet<PeerId>? gossipsubPeers) && gossipsubPeers.Contains(peerId));
+    }
+
+    private IEnumerable<PeerId> GetDirectPeersForTopic(string topic)
+    {
+        return directPeers.Keys.Where(peerId => IsDirectPeerSubscribedTo(peerId, topic));
     }
 
     public Task Heartbeat()
@@ -437,6 +491,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     // Need to graft more peers - exclude peers with negative scores
                     PeerId[] peersToGraft = gPeers[topic]
                         .Where(p => !meshPeers.Contains(p)
+                            && !IsDirectPeer(p)
                             && GetPeerScore(p) >= 0  // Only graft non-negative scoring peers
                             && (peerState.GetValueOrDefault(p)?.Backoff.TryGetValue(topic, out DateTime backoff) != true || backoff < DateTime.Now))
                         .Take(_settings.Degree - meshPeers.Count).ToArray();
@@ -522,7 +577,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     int peerCountToAdd = _settings.Degree - fanout[fanoutTopic].Count;
                     if (peerCountToAdd > 0)
                     {
-                        foreach (PeerId? peerId in gPeers[fanoutTopic].Where(p => !fanout[fanoutTopic].Contains(p)).Take(peerCountToAdd))
+                        foreach (PeerId? peerId in gPeers[fanoutTopic].Where(p => !fanout[fanoutTopic].Contains(p) && !IsDirectPeer(p)).Take(peerCountToAdd))
                         {
                             fanout[fanoutTopic].Add(peerId);
                         }
@@ -557,6 +612,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 PeerId[] eligiblePeers = topicGossipsubPeers
                     .Where(p => !topicMesh.Contains(p)
                         && !fanoutPeers.Contains(p)
+                        && !IsDirectPeer(p)
                         && GetPeerScore(p) >= _settings.GossipThreshold)
                     .ToArray();
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -418,7 +418,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     private static IReadOnlyDictionary<PeerId, Multiaddress[]> CreateDirectPeers(IEnumerable<Multiaddress>? configuredPeers)
     {
         return (configuredPeers ?? [])
-            .Select(address => (PeerId: address.GetPeerId() ?? throw new ArgumentException("A direct peer address must include a peer ID.", nameof(configuredPeers)), Address: address))
+            .Select(address => (PeerId: address.GetPeerId() ?? throw new ArgumentException("A direct peer address must include a peer ID.", nameof(PubsubSettings.DirectPeers)), Address: address))
             .GroupBy(entry => entry.PeerId)
             .ToDictionary(group => group.Key, group => group.Select(entry => entry.Address).ToArray());
     }


### PR DESCRIPTION
## Summary
- add reciprocal direct-peer configuration and periodic reconnection
- forward valid subscribed-topic messages directly while excluding direct peers from mesh, fanout, and gossip selection
- reject direct-peer GRAFTs with PRUNE and cover delivery, mesh isolation, startup dialing, and configuration validation

## Validation
- Pubsub protocol unit tests