### PR TITLE
Use a bounded Gossipsub message cache

### DIFF
--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/MessageCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/MessageCacheTests.cs
@@ -94,6 +94,25 @@ public class MessageCacheTests
     }
 
     [Test]
+    public void Clear_ReleasesMessagesAndHistory()
+    {
+        MessageCache cache = new(gossipWindows: 2, historyWindows: 3, maxEntries: 10, maxBytes: 1024);
+        MessageId id = new([1]);
+
+        cache.Put(id, CreateMessage("topic", [1, 2, 3]));
+        cache.Clear();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Count, Is.Zero);
+            Assert.That(cache.CachedBytes, Is.Zero);
+            Assert.That(cache.HistoryEntryCount, Is.Zero);
+            Assert.That(cache.TryGet(id, out _), Is.False);
+            Assert.That(cache.GetGossipIds("topic"), Is.Empty);
+        });
+    }
+
+    [Test]
     public async Task PublishedMessages_AreAvailableForIwantResponses()
     {
         const string topic = "topic";

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/MessageCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/MessageCacheTests.cs
@@ -67,6 +67,7 @@ public class MessageCacheTests
         Assert.Multiple(() =>
         {
             Assert.That(cache.Count, Is.EqualTo(2));
+            Assert.That(cache.HistoryEntryCount, Is.EqualTo(2));
             Assert.That(cache.TryGet(firstId, out _), Is.False);
             Assert.That(cache.GetGossipIds("topic"), Does.Not.Contain(firstId));
         });
@@ -129,6 +130,7 @@ public class MessageCacheTests
 
     [TestCase(0, 1, 1, 1)]
     [TestCase(2, 1, 1, 1)]
+    [TestCase(1, 1, 1, 1)]
     [TestCase(1, 1, 0, 1)]
     [TestCase(1, 1, 1, 0)]
     public void Constructor_RejectsInvalidLimits(int gossipWindows, int historyWindows, int maxEntries, int maxBytes)

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/MessageCacheTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/MessageCacheTests.cs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Google.Protobuf;
+using Multiformats.Address;
+using Nethermind.Libp2p.Core.Discovery;
+using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+using System.Collections.ObjectModel;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
+
+[TestFixture]
+public class MessageCacheTests
+{
+    [Test]
+    public void GossipIds_UseOnlyTheMostRecentWindows()
+    {
+        MessageCache cache = new(gossipWindows: 2, historyWindows: 3, maxEntries: 10, maxBytes: 1024);
+        MessageId firstId = new([1]);
+        MessageId secondId = new([2]);
+        MessageId thirdId = new([3]);
+
+        cache.Put(firstId, CreateMessage("topic", [1]));
+        cache.Shift();
+        cache.Put(secondId, CreateMessage("topic", [2]));
+        cache.Shift();
+        cache.Put(thirdId, CreateMessage("topic", [3]));
+
+        Assert.That(cache.GetGossipIds("topic"), Is.EquivalentTo(new[] { secondId, thirdId }));
+    }
+
+    [Test]
+    public void Shift_DropsTheOldestHistoryWindow()
+    {
+        MessageCache cache = new(gossipWindows: 2, historyWindows: 3, maxEntries: 10, maxBytes: 1024);
+        MessageId firstId = new([1]);
+        MessageId secondId = new([2]);
+        MessageId thirdId = new([3]);
+
+        cache.Put(firstId, CreateMessage("topic", [1]));
+        cache.Shift();
+        cache.Put(secondId, CreateMessage("topic", [2]));
+        cache.Shift();
+        cache.Put(thirdId, CreateMessage("topic", [3]));
+        cache.Shift();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.TryGet(firstId, out _), Is.False);
+            Assert.That(cache.TryGet(secondId, out _), Is.True);
+            Assert.That(cache.TryGet(thirdId, out _), Is.True);
+        });
+    }
+
+    [Test]
+    public void Put_EvictsTheOldestEntryWhenTheEntryLimitIsReached()
+    {
+        MessageCache cache = new(gossipWindows: 2, historyWindows: 3, maxEntries: 2, maxBytes: 1024);
+        MessageId firstId = new([1]);
+        MessageId secondId = new([2]);
+        MessageId thirdId = new([3]);
+
+        cache.Put(firstId, CreateMessage("topic", [1]));
+        cache.Put(secondId, CreateMessage("topic", [2]));
+        cache.Put(thirdId, CreateMessage("topic", [3]));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Count, Is.EqualTo(2));
+            Assert.That(cache.TryGet(firstId, out _), Is.False);
+            Assert.That(cache.GetGossipIds("topic"), Does.Not.Contain(firstId));
+        });
+    }
+
+    [Test]
+    public void Put_EvictsTheOldestEntryWhenTheByteLimitIsReached()
+    {
+        Message first = CreateMessage("topic", new byte[128]);
+        Message second = CreateMessage("topic", new byte[128]);
+        MessageCache cache = new(gossipWindows: 2, historyWindows: 3, maxEntries: 10, maxBytes: first.CalculateSize() + second.CalculateSize() - 1);
+        MessageId firstId = new([1]);
+        MessageId secondId = new([2]);
+
+        cache.Put(firstId, first);
+        cache.Put(secondId, second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.TryGet(firstId, out _), Is.False);
+            Assert.That(cache.TryGet(secondId, out _), Is.True);
+            Assert.That(cache.CachedBytes, Is.EqualTo(second.CalculateSize()));
+        });
+    }
+
+    [Test]
+    public async Task PublishedMessages_AreAvailableForIwantResponses()
+    {
+        const string topic = "topic";
+        PeerStore peerStore = new();
+        PubsubRouter router = new(peerStore, new PubsubSettings { HeartbeatInterval = int.MaxValue });
+        ILocalPeer localPeer = Substitute.For<ILocalPeer>();
+        localPeer.Identity.Returns(TestPeers.Identity(1));
+        localPeer.ListenAddresses.Returns(new ObservableCollection<Multiaddress>());
+        using CancellationTokenSource cancellation = new();
+        await router.StartAsync(localPeer, cancellation.Token);
+
+        Multiaddress remoteAddress = TestPeers.Multiaddr(2);
+        PeerId remotePeerId = remoteAddress.GetPeerId()!;
+        List<Rpc> sentRpcs = [];
+        TaskCompletionSource connection = new();
+        _ = router.GetTopic(topic);
+        router.OutboundConnection(remoteAddress, PubsubRouter.GossipsubProtocolVersionV11, connection.Task, sentRpcs.Add);
+        router.OnRpc(remotePeerId, new Rpc().WithTopics([topic], []));
+        sentRpcs.Clear();
+
+        router.Publish(topic, [1, 2, 3]);
+        Message published = sentRpcs.Single().Publish.Single();
+        MessageId messageId = PubsubSettings.ConcatFromAndSeqno(published);
+        sentRpcs.Clear();
+
+        Rpc request = new() { Control = new ControlMessage() };
+        request.Control.Iwant.Add(new ControlIWant { MessageIDs = { ByteString.CopyFrom(messageId.Bytes) } });
+        router.OnRpc(remotePeerId, request);
+
+        Assert.That(sentRpcs.Single().Publish.Single().Data.ToByteArray(), Is.EqualTo(new byte[] { 1, 2, 3 }));
+        connection.SetResult();
+        cancellation.Cancel();
+    }
+
+    [TestCase(0, 1, 1, 1)]
+    [TestCase(2, 1, 1, 1)]
+    [TestCase(1, 1, 0, 1)]
+    [TestCase(1, 1, 1, 0)]
+    public void Constructor_RejectsInvalidLimits(int gossipWindows, int historyWindows, int maxEntries, int maxBytes)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MessageCache(gossipWindows, historyWindows, maxEntries, maxBytes));
+    }
+
+    private static Message CreateMessage(string topic, byte[] data) => new()
+    {
+        Topic = topic,
+        Data = ByteString.CopyFrom(data),
+    };
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/TopicLifecycleTests.cs
@@ -202,6 +202,36 @@ public class TopicLifecycleTests
     }
 
     [Test]
+    public void RejectedMessageIsNotRequestedAgainFromIhave()
+    {
+        const string topicName = "topic-lifecycle";
+        PubsubRouter router = new(new PeerStore())
+        {
+            VerifyMessage = _ => MessageValidity.Rejected,
+        };
+        _ = router.GetTopic(topicName);
+        Multiaddress peerAddress = TestPeers.Multiaddr(3);
+        PeerId peerId = peerAddress.GetPeerId()!;
+        TaskCompletionSource connectionClosed = new();
+        List<Rpc> sent = [];
+        Rpc rejectedMessage = CreateMessage(topicName, TestPeers.Identity(2), 1);
+        MessageId messageId = PubsubSettings.ConcatFromAndSeqno(rejectedMessage.Publish.Single());
+
+        router.OutboundConnection(peerAddress, PubsubRouter.GossipsubProtocolVersionV11, connectionClosed.Task, sent.Add);
+        sent.Clear();
+        router.OnRpc(peerId, rejectedMessage);
+        sent.Clear();
+
+        Rpc ihave = new() { Control = new ControlMessage() };
+        ihave.Control.Ihave.Add(new ControlIHave { TopicID = topicName, MessageIDs = { ByteString.CopyFrom(messageId.Bytes) } });
+        router.OnRpc(peerId, ihave);
+
+        Assert.That(sent, Is.Empty);
+
+        connectionClosed.SetResult();
+    }
+
+    [Test]
     public void Topic_SubscribeMovesFanoutPeersIntoTheMesh()
     {
         const string topicName = "topic-lifecycle";

--- a/src/libp2p/Libp2p.Protocols.Pubsub/MessageCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/MessageCache.cs
@@ -148,6 +148,21 @@ internal sealed class MessageCache
         }
     }
 
+    internal void Clear()
+    {
+        lock (sync)
+        {
+            messages.Clear();
+            insertionOrder.Clear();
+            foreach (LinkedList<Entry> window in history)
+            {
+                window.Clear();
+            }
+
+            cachedBytes = 0;
+        }
+    }
+
     internal int Count
     {
         get

--- a/src/libp2p/Libp2p.Protocols.Pubsub/MessageCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/MessageCache.cs
@@ -20,12 +20,13 @@ internal sealed class MessageCache
         public Message Message { get; } = message;
         public int Size { get; } = size;
         public LinkedListNode<Entry>? InsertionNode { get; set; }
+        public LinkedListNode<Entry>? HistoryNode { get; set; }
     }
 
     private readonly object sync = new();
     private readonly Dictionary<MessageId, Entry> messages = [];
     private readonly LinkedList<Entry> insertionOrder = [];
-    private readonly List<Entry>[] history;
+    private readonly LinkedList<Entry>[] history;
     private readonly int gossipWindows;
     private readonly int maxEntries;
     private readonly long maxBytes;
@@ -38,7 +39,7 @@ internal sealed class MessageCache
             throw new ArgumentOutOfRangeException(nameof(historyWindows));
         }
 
-        if (gossipWindows <= 0 || gossipWindows > historyWindows)
+        if (gossipWindows <= 0 || gossipWindows >= historyWindows)
         {
             throw new ArgumentOutOfRangeException(nameof(gossipWindows));
         }
@@ -56,7 +57,7 @@ internal sealed class MessageCache
         this.gossipWindows = gossipWindows;
         this.maxEntries = maxEntries;
         this.maxBytes = maxBytes;
-        history = Enumerable.Range(0, historyWindows).Select(_ => new List<Entry>()).ToArray();
+        history = Enumerable.Range(0, historyWindows).Select(_ => new LinkedList<Entry>()).ToArray();
     }
 
     public void Put(MessageId id, Message message)
@@ -87,8 +88,8 @@ internal sealed class MessageCache
 
             Entry entry = new(id, message, size);
             entry.InsertionNode = insertionOrder.AddLast(entry);
+            entry.HistoryNode = history[0].AddLast(entry);
             messages.Add(id, entry);
-            history[0].Add(entry);
             cachedBytes += size;
         }
     }
@@ -132,13 +133,11 @@ internal sealed class MessageCache
     {
         lock (sync)
         {
-            List<Entry> expiredWindow = history[^1];
-            foreach (Entry entry in expiredWindow)
+            LinkedList<Entry> expiredWindow = history[^1];
+            while (expiredWindow.First is LinkedListNode<Entry> node)
             {
-                Remove(entry);
+                Remove(node.Value);
             }
-
-            expiredWindow.Clear();
 
             for (int window = history.Length - 1; window > 0; window--)
             {
@@ -171,6 +170,17 @@ internal sealed class MessageCache
         }
     }
 
+    internal int HistoryEntryCount
+    {
+        get
+        {
+            lock (sync)
+            {
+                return history.Sum(window => window.Count);
+            }
+        }
+    }
+
     private void Remove(Entry entry)
     {
         if (!messages.Remove(entry.Id))
@@ -181,5 +191,10 @@ internal sealed class MessageCache
         cachedBytes -= entry.Size;
         insertionOrder.Remove(entry.InsertionNode!);
         entry.InsertionNode = null;
+        if (entry.HistoryNode is LinkedListNode<Entry> historyNode)
+        {
+            historyNode.List?.Remove(historyNode);
+            entry.HistoryNode = null;
+        }
     }
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/MessageCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/MessageCache.cs
@@ -132,17 +132,20 @@ internal sealed class MessageCache
     {
         lock (sync)
         {
-            foreach (Entry entry in history[^1])
+            List<Entry> expiredWindow = history[^1];
+            foreach (Entry entry in expiredWindow)
             {
                 Remove(entry);
             }
+
+            expiredWindow.Clear();
 
             for (int window = history.Length - 1; window > 0; window--)
             {
                 history[window] = history[window - 1];
             }
 
-            history[0] = [];
+            history[0] = expiredWindow;
         }
     }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/MessageCache.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/MessageCache.cs
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Nethermind.Libp2p.Core;
+using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub;
+
+/// <summary>
+/// A bounded sliding-window cache for Gossipsub gossip and IWANT responses.
+/// Messages are retained for a fixed number of heartbeat windows, while IHAVE
+/// advertisements use only the most recent windows.
+/// </summary>
+internal sealed class MessageCache
+{
+    private sealed class Entry(MessageId id, Message message, int size)
+    {
+        public MessageId Id { get; } = id;
+        public string Topic { get; } = message.Topic;
+        public Message Message { get; } = message;
+        public int Size { get; } = size;
+        public LinkedListNode<Entry>? InsertionNode { get; set; }
+    }
+
+    private readonly object sync = new();
+    private readonly Dictionary<MessageId, Entry> messages = [];
+    private readonly LinkedList<Entry> insertionOrder = [];
+    private readonly List<Entry>[] history;
+    private readonly int gossipWindows;
+    private readonly int maxEntries;
+    private readonly long maxBytes;
+    private long cachedBytes;
+
+    public MessageCache(int gossipWindows, int historyWindows, int maxEntries, long maxBytes)
+    {
+        if (historyWindows <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(historyWindows));
+        }
+
+        if (gossipWindows <= 0 || gossipWindows > historyWindows)
+        {
+            throw new ArgumentOutOfRangeException(nameof(gossipWindows));
+        }
+
+        if (maxEntries <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxEntries));
+        }
+
+        if (maxBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxBytes));
+        }
+
+        this.gossipWindows = gossipWindows;
+        this.maxEntries = maxEntries;
+        this.maxBytes = maxBytes;
+        history = Enumerable.Range(0, historyWindows).Select(_ => new List<Entry>()).ToArray();
+    }
+
+    public void Put(MessageId id, Message message)
+    {
+        lock (sync)
+        {
+            if (messages.ContainsKey(id))
+            {
+                return;
+            }
+
+            int size = message.CalculateSize();
+            if (size > maxBytes)
+            {
+                return;
+            }
+
+            while (messages.Count >= maxEntries || cachedBytes + size > maxBytes)
+            {
+                LinkedListNode<Entry>? oldest = insertionOrder.First;
+                if (oldest is null)
+                {
+                    return;
+                }
+
+                Remove(oldest.Value);
+            }
+
+            Entry entry = new(id, message, size);
+            entry.InsertionNode = insertionOrder.AddLast(entry);
+            messages.Add(id, entry);
+            history[0].Add(entry);
+            cachedBytes += size;
+        }
+    }
+
+    public bool TryGet(MessageId id, out Message message)
+    {
+        lock (sync)
+        {
+            if (messages.TryGetValue(id, out Entry? entry))
+            {
+                message = entry.Message;
+                return true;
+            }
+        }
+
+        message = null!;
+        return false;
+    }
+
+    public IReadOnlyList<MessageId> GetGossipIds(string topic)
+    {
+        lock (sync)
+        {
+            List<MessageId> result = [];
+            for (int window = 0; window < gossipWindows; window++)
+            {
+                foreach (Entry entry in history[window])
+                {
+                    if (entry.Topic == topic && messages.ContainsKey(entry.Id))
+                    {
+                        result.Add(entry.Id);
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+
+    public void Shift()
+    {
+        lock (sync)
+        {
+            foreach (Entry entry in history[^1])
+            {
+                Remove(entry);
+            }
+
+            for (int window = history.Length - 1; window > 0; window--)
+            {
+                history[window] = history[window - 1];
+            }
+
+            history[0] = [];
+        }
+    }
+
+    internal int Count
+    {
+        get
+        {
+            lock (sync)
+            {
+                return messages.Count;
+            }
+        }
+    }
+
+    internal long CachedBytes
+    {
+        get
+        {
+            lock (sync)
+            {
+                return cachedBytes;
+            }
+        }
+    }
+
+    private void Remove(Entry entry)
+    {
+        if (!messages.Remove(entry.Id))
+        {
+            return;
+        }
+
+        cachedBytes -= entry.Size;
+        insertionOrder.Remove(entry.InsertionNode!);
+        entry.InsertionNode = null;
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -39,6 +39,8 @@ public class PubsubSettings
     public int FanoutTtl { get; set; } = 60 * 1000; // Time-to-live for each topic's fanout state 	60 seconds
     public int mcache_len { get; set; } = 5; // Number of history windows in message cache 	5
     public int mcache_gossip { get; set; } = 3; // Number of history windows to use when emitting gossip 	3
+    public int MaxMessageCacheEntries { get; set; } = 10_000;
+    public int MaxMessageCacheBytes { get; set; } = 64 * 1024 * 1024;
     public int MessageCacheTtl { get; set; } = 2 * 60 * 1000; // Expiry time for cache of seen message ids 	2 minutes
     // Maximum incoming RPC frame size 1 MiB
     public int MaxRpcBytes

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -44,6 +44,9 @@ public class PubsubSettings
 
     /// <summary>Maximum total serialized message bytes retained for gossip and IWANT responses.</summary>
     public long MaxMessageCacheBytes { get; set; } = 64L * 1024 * 1024;
+
+    /// <summary>Maximum valid or rejected message IDs retained by each TTL deduplication cache.</summary>
+    public int MaxSeenMessageIds { get; set; } = 10_000;
     public int MessageCacheTtl { get; set; } = 2 * 60 * 1000; // Expiry time for cache of seen message ids 	2 minutes
     // Maximum incoming RPC frame size 1 MiB
     public int MaxRpcBytes

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -39,8 +39,11 @@ public class PubsubSettings
     public int FanoutTtl { get; set; } = 60 * 1000; // Time-to-live for each topic's fanout state 	60 seconds
     public int mcache_len { get; set; } = 5; // Number of history windows in message cache 	5
     public int mcache_gossip { get; set; } = 3; // Number of history windows to use when emitting gossip 	3
+    /// <summary>Maximum number of messages retained for gossip and IWANT responses.</summary>
     public int MaxMessageCacheEntries { get; set; } = 10_000;
-    public int MaxMessageCacheBytes { get; set; } = 64 * 1024 * 1024;
+
+    /// <summary>Maximum total serialized message bytes retained for gossip and IWANT responses.</summary>
+    public long MaxMessageCacheBytes { get; set; } = 64L * 1024 * 1024;
     public int MessageCacheTtl { get; set; } = 2 * 60 * 1000; // Expiry time for cache of seen message ids 	2 minutes
     // Maximum incoming RPC frame size 1 MiB
     public int MaxRpcBytes

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -167,7 +167,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
         if (logger?.IsEnabled(LogLevel.Trace) is true)
         {
-            int knownMessages = messages.Select(_settings.GetMessageId).Count(messageId => _limboMessageCache.Contains(messageId) || _messageCache!.Contains(messageId));
+            int knownMessages = messages.Select(_settings.GetMessageId).Count(messageId => _limboMessageCache.Contains(messageId) || _seenMessages.Contains(messageId));
             logger?.LogTrace($"Messages received: {messages.Count()}, already known: {knownMessages}. All: {string.Join(",", messages.Select(_settings.GetMessageId))}.");
         }
         else
@@ -179,7 +179,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         {
             MessageId messageId = _settings.GetMessageId(message);
 
-            if (_limboMessageCache.Contains(messageId) || _messageCache!.Contains(messageId))
+            if (_limboMessageCache.Contains(messageId) || _seenMessages.Contains(messageId))
             {
                 continue;
             }
@@ -189,11 +189,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             switch (validity)
             {
                 case MessageValidity.Rejected:
-                    _limboMessageCache.Add(messageId, new(messageId, message));
+                    _limboMessageCache.Add(messageId);
                     RecordMessageDelivery(peerId, message, message.Topic, false);  // Track invalid message
                     continue;
                 case MessageValidity.Ignored:
-                    _limboMessageCache.Add(messageId, new(messageId, message));
+                    _limboMessageCache.Add(messageId);
                     continue;
                 case MessageValidity.Throttled:
                     continue;
@@ -201,12 +201,13 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
             if (!message.VerifySignature(_settings.DefaultSignaturePolicy))
             {
-                _limboMessageCache!.Add(messageId, new(messageId, message));
+                _limboMessageCache.Add(messageId);
                 RecordMessageDelivery(peerId, message, message.Topic, false);  // Track invalid message
                 continue;
             }
 
-            _messageCache.Add(messageId, new(messageId, message));
+            _seenMessages.Add(messageId);
+            _messageCache.Put(messageId, message);
 
             // Record valid message delivery for scoring
             RecordMessageDelivery(peerId, message, message.Topic, true);
@@ -436,7 +437,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         foreach (ControlIHave? ihave in ihaves.Where(iw => topicState.GetValueOrDefault(iw.TopicID)?.IsSubscribed is true))
         {
             messageIds.AddRange(ihave.MessageIDs.Select(m => new MessageId(m.ToByteArray()))
-                .Where(mid => !_messageCache.Contains(mid)));
+                .Where(mid => !_seenMessages.Contains(mid)));
         }
 
         if (messageIds.Any())
@@ -458,8 +459,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         List<Message> messages = [];
         foreach (MessageId mId in messageIds)
         {
-            Message message = _messageCache.Get(mId).Message;
-            if (message != default)
+            if (_messageCache.TryGet(mId, out Message message))
             {
                 messages.Add(message);
             }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -437,7 +437,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         foreach (ControlIHave? ihave in ihaves.Where(iw => topicState.GetValueOrDefault(iw.TopicID)?.IsSubscribed is true))
         {
             messageIds.AddRange(ihave.MessageIDs.Select(m => new MessageId(m.ToByteArray()))
-                .Where(mid => !_seenMessages.Contains(mid)));
+                .Where(mid => !_seenMessages.Contains(mid) && !_limboMessageCache.Contains(mid)));
         }
 
         if (messageIds.Any())

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Topics.cs
@@ -191,6 +191,10 @@ public partial class PubsubRouter
 
             ulong seqNo = this.seqNo++;
             Rpc rpc = new Rpc().WithMessages(topicId, seqNo, localPeer.Identity.PeerId.Bytes, message, localPeer.Identity);
+            Message publishedMessage = rpc.Publish[0];
+            MessageId messageId = _settings.GetMessageId(publishedMessage);
+            _seenMessages.Add(messageId);
+            _messageCache.Put(messageId, publishedMessage);
 
             HashSet<PeerId> directRecipients = GetDirectPeersForTopic(topicId).ToHashSet();
             foreach (PeerId peerId in directRecipients)

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -285,8 +285,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
         directPeers = CreateDirectPeers(_settings.DirectPeers);
         _messageCache = new(_settings.mcache_gossip, _settings.mcache_len, _settings.MaxMessageCacheEntries, _settings.MaxMessageCacheBytes);
-        _seenMessages = new(_settings.MessageCacheTtl);
-        _limboMessageCache = new(_settings.MessageCacheTtl);
+        _seenMessages = new(_settings.MessageCacheTtl, _settings.MaxSeenMessageIds);
+        _limboMessageCache = new(_settings.MessageCacheTtl, _settings.MaxSeenMessageIds);
         _idontwantMessages = new(_settings.MessageCacheTtl);
         partialMessageGossip = new(_settings.MaxPartialMessageGroupsPerTopic, _settings.PartialMessageGossipTtlHeartbeats);
     }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -227,8 +227,9 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     internal int MaxRpcBytes => _settings.MaxRpcBytes;
 
     private readonly PubsubSettings _settings;
-    private readonly TtlCache<MessageId, MessageWithId> _messageCache;
-    private readonly TtlCache<MessageId, MessageWithId> _limboMessageCache;
+    private readonly MessageCache _messageCache;
+    private readonly TtlCache<MessageId> _seenMessages;
+    private readonly TtlCache<MessageId> _limboMessageCache;
     private readonly TtlCache<(PeerId, MessageId)> _idontwantMessages;
     private readonly PartialMessageGossipCache partialMessageGossip;
 
@@ -283,7 +284,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         }
 
         directPeers = CreateDirectPeers(_settings.DirectPeers);
-        _messageCache = new(_settings.MessageCacheTtl);
+        _messageCache = new(_settings.mcache_gossip, _settings.mcache_len, _settings.MaxMessageCacheEntries, _settings.MaxMessageCacheBytes);
+        _seenMessages = new(_settings.MessageCacheTtl);
         _limboMessageCache = new(_settings.MessageCacheTtl);
         _idontwantMessages = new(_settings.MessageCacheTtl);
         partialMessageGossip = new(_settings.MaxPartialMessageGroupsPerTopic, _settings.PartialMessageGossipTtlHeartbeats);
@@ -392,8 +394,9 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
     public void Dispose()
     {
-        _messageCache.Dispose();
+        _seenMessages.Dispose();
         _limboMessageCache.Dispose();
+        _idontwantMessages.Dispose();
     }
 
     private void Reconnect(CancellationToken token)
@@ -585,13 +588,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 }
             }
 
-            IEnumerable<IGrouping<string, MessageWithId>> msgs = _messageCache.ToList().GroupBy(m => m.Message.Topic);
-
             foreach (string topic in gPeers.Keys.Concat(fanout.Keys).Distinct()
                 .Where(topic => topicState.GetValueOrDefault(topic)?.IsSubscribed is true || fanout.ContainsKey(topic))
                 .ToArray())
             {
-                IGrouping<string, MessageWithId>? msgsInTopic = msgs.FirstOrDefault(mit => mit.Key == topic);
+                IReadOnlyList<MessageId> messageIds = _messageCache.GetGossipIds(topic);
                 bool canGossipPartialMessages =
                     onPartialGossip is not null &&
                     _settings.EnablePartialMessages &&
@@ -600,7 +601,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 IReadOnlyList<byte[]> partialMessageGroupIds = canGossipPartialMessages
                     ? partialMessageGossip.GetGroupIds(topic)
                     : [];
-                if (msgsInTopic is null && partialMessageGroupIds.Count == 0)
+                if (messageIds.Count == 0 && partialMessageGroupIds.Count == 0)
                 {
                     continue;
                 }
@@ -639,10 +640,10 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     }
                 }
 
-                if (msgsInTopic is not null)
+                if (messageIds.Count != 0)
                 {
                     ControlIHave ihave = new() { TopicID = topic };
-                    ihave.MessageIDs.AddRange(msgsInTopic.Select(m => ByteString.CopyFrom(m.Id.Bytes)));
+                    ihave.MessageIDs.AddRange(messageIds.Select(id => ByteString.CopyFrom(id.Bytes)));
                     foreach (PeerId peer in gossipPeers)
                     {
                         peerMessages.GetOrAdd(peer, _ => new Rpc())
@@ -652,6 +653,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             }
 
             partialMessageGossip.Heartbeat();
+            _messageCache.Shift();
         }
 
         foreach (KeyValuePair<PeerId, Rpc> peerMessage in peerMessages)
@@ -797,10 +799,4 @@ internal enum ConnectionInitiation
 {
     Local,
     Remote,
-}
-
-internal readonly struct MessageWithId(MessageId id, Message message)
-{
-    public MessageId Id { get; } = id;
-    public Message Message { get; } = message;
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -394,6 +394,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
     public void Dispose()
     {
+        _messageCache.Clear();
         _seenMessages.Dispose();
         _limboMessageCache.Dispose();
         _idontwantMessages.Dispose();


### PR DESCRIPTION
## Summary
- replace TTL-based gossip history with bounded heartbeat windows
- retain published messages for IHAVE gossip and IWANT responses while keeping duplicate suppression separate
- cap cache entries and bytes, with coverage for expiry, capacity, and local-publication retrieval

## Validation
- Pubsub protocol unit tests