### PR TITLE
Bound Gossipsub control-plane work

### DIFF
--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Google.Protobuf;
+using Multiformats.Address;
+using Nethermind.Libp2p.Core.Discovery;
+using Nethermind.Libp2p.Protocols.Pubsub.Dto;
+using System.Collections.ObjectModel;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub.Tests;
+
+[TestFixture]
+public class GossipsubControlLimitsTests
+{
+    [Test]
+    public async Task Ihave_RespectsTheHeartbeatAndMessageIdLimits()
+    {
+        await using RouterSetup setup = await RouterSetup.Create(new PubsubSettings
+        {
+            HeartbeatInterval = int.MaxValue,
+            MaxIHaveMessages = 1,
+            MaxIHaveLength = 2,
+        });
+
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIhave(setup.Topic, [1], [2], [3]));
+
+        Assert.That(GetIwantIds(setup.SentRpcs), Has.Count.EqualTo(2));
+        setup.SentRpcs.Clear();
+
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIhave(setup.Topic, [4]));
+        Assert.That(GetIwantIds(setup.SentRpcs), Is.Empty);
+
+        await setup.Router.Heartbeat();
+        setup.SentRpcs.Clear();
+
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIhave(setup.Topic, [5]));
+        Assert.That(GetIwantIds(setup.SentRpcs), Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Iwant_UsesRetransmissionAndResponseByteLimits()
+    {
+        await using RouterSetup setup = await RouterSetup.Create(new PubsubSettings
+        {
+            HeartbeatInterval = int.MaxValue,
+            GossipRetransmission = 2,
+            MaxIwantResponseBytes = 200,
+        });
+
+        MessageId first = setup.Publish([1, 2, 3]);
+        MessageId second = setup.Publish(new byte[64]);
+
+        setup.SentRpcs.Clear();
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(first, second));
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Has.Count.EqualTo(1));
+
+        setup.SentRpcs.Clear();
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(first));
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Has.Count.EqualTo(1));
+
+        setup.SentRpcs.Clear();
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(first));
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Is.Empty);
+    }
+
+    [Test]
+    public async Task Idontwant_SuppressesResponsesUntilItsHeartbeatTtlExpires()
+    {
+        await using RouterSetup setup = await RouterSetup.Create(new PubsubSettings
+        {
+            HeartbeatInterval = int.MaxValue,
+            IdontwantTtlHeartbeats = 1,
+        });
+        MessageId messageId = setup.Publish([1, 2, 3]);
+        setup.SentRpcs.Clear();
+
+        Rpc dontWant = new() { Control = new ControlMessage() };
+        dontWant.Control.Idontwant.Add(new ControlIDontWant { MessageIDs = { ByteString.CopyFrom(messageId.Bytes) } });
+        setup.Router.OnRpc(setup.RemotePeerId, dontWant);
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(messageId));
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Is.Empty);
+
+        await setup.Router.Heartbeat();
+        setup.SentRpcs.Clear();
+
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(messageId));
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void IwantPromises_AreBoundedAndFulfilledByTheMessageId()
+    {
+        IwantPromiseTracker tracker = new(maxPromises: 1);
+        PeerId firstPeer = TestPeers.PeerId(1);
+        PeerId secondPeer = TestPeers.PeerId(2);
+        MessageId firstMessage = new([1]);
+        MessageId secondMessage = new([2]);
+
+        tracker.Add(firstPeer, [firstMessage], DateTime.UtcNow.AddSeconds(-1));
+        tracker.Add(secondPeer, [secondMessage], DateTime.UtcNow.AddSeconds(-1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tracker.Count, Is.EqualTo(1));
+            Assert.That(tracker.TakeExpired(DateTime.UtcNow), Is.EquivalentTo(new Dictionary<PeerId, int> { [firstPeer] = 1 }));
+            Assert.That(tracker.Count, Is.Zero);
+        });
+
+        tracker.Add(firstPeer, [firstMessage], DateTime.UtcNow.AddSeconds(1));
+        tracker.Fulfill(firstMessage);
+        Assert.That(tracker.Count, Is.Zero);
+    }
+
+    [TestCase(0, 1, 1, 1, 1, 1, 1, 1)]
+    [TestCase(1, 0, 1, 1, 1, 1, 1, 1)]
+    [TestCase(1, 1, 0, 1, 1, 1, 1, 1)]
+    [TestCase(1, 1, 1, 0, 1, 1, 1, 1)]
+    [TestCase(1, 1, 1, 1, 0, 1, 1, 1)]
+    [TestCase(1, 1, 1, 1, 1, 0, 1, 1)]
+    [TestCase(1, 1, 1, 1, 1, 1, 0, 1)]
+    [TestCase(1, 1, 1, 1, 1, 1, 1, 0)]
+    public void Router_RejectsInvalidControlLimits(
+        int maxIhaveMessages,
+        int maxIhaveLength,
+        int retransmission,
+        int responseBytes,
+        int promises,
+        int followupTime,
+        int idontwantTtl,
+        int maxIdontwantMessages)
+    {
+        PubsubSettings settings = new()
+        {
+            MaxIHaveMessages = maxIhaveMessages,
+            MaxIHaveLength = maxIhaveLength,
+            GossipRetransmission = retransmission,
+            MaxIwantResponseBytes = responseBytes,
+            MaxIwantPromises = promises,
+            IWantFollowupTime = followupTime,
+            IdontwantTtlHeartbeats = idontwantTtl,
+            MaxIdontwantMessages = maxIdontwantMessages,
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PubsubRouter(new PeerStore(), settings));
+    }
+
+    private static Rpc CreateIhave(string topic, params byte[][] ids)
+    {
+        Rpc rpc = new() { Control = new ControlMessage() };
+        ControlIHave ihave = new() { TopicID = topic };
+        ihave.MessageIDs.AddRange(ids.Select(ByteString.CopyFrom));
+        rpc.Control.Ihave.Add(ihave);
+        return rpc;
+    }
+
+    private static Rpc CreateIwant(params MessageId[] ids)
+    {
+        Rpc rpc = new() { Control = new ControlMessage() };
+        rpc.Control.Iwant.Add(new ControlIWant { MessageIDs = { ids.Select(id => ByteString.CopyFrom(id.Bytes)) } });
+        return rpc;
+    }
+
+    private static IReadOnlyList<ByteString> GetIwantIds(IEnumerable<Rpc> rpcs) => rpcs
+        .Where(rpc => rpc.Control is not null)
+        .SelectMany(rpc => rpc.Control.Iwant)
+        .SelectMany(iwant => iwant.MessageIDs)
+        .ToArray();
+
+    private static IReadOnlyList<Message> GetPublishedMessages(IEnumerable<Rpc> rpcs) => rpcs
+        .SelectMany(rpc => rpc.Publish)
+        .ToArray();
+
+    private sealed class RouterSetup : IAsyncDisposable
+    {
+        private readonly CancellationTokenSource cancellation = new();
+        private readonly TaskCompletionSource connection = new();
+
+        private RouterSetup(PubsubRouter router, string topic, PeerId remotePeerId, List<Rpc> sentRpcs)
+        {
+            Router = router;
+            Topic = topic;
+            RemotePeerId = remotePeerId;
+            SentRpcs = sentRpcs;
+        }
+
+        public PubsubRouter Router { get; }
+        public string Topic { get; }
+        public PeerId RemotePeerId { get; }
+        public List<Rpc> SentRpcs { get; }
+
+        public static async Task<RouterSetup> Create(PubsubSettings settings)
+        {
+            const string topic = "topic";
+            PubsubRouter router = new(new PeerStore(), settings);
+            ILocalPeer localPeer = Substitute.For<ILocalPeer>();
+            localPeer.Identity.Returns(TestPeers.Identity(1));
+            localPeer.ListenAddresses.Returns(new ObservableCollection<Multiaddress>());
+
+            RouterSetup setup = new(router, topic, TestPeers.PeerId(2), []);
+            await router.StartAsync(localPeer, setup.cancellation.Token);
+            _ = router.GetTopic(topic);
+            Multiaddress remoteAddress = TestPeers.Multiaddr(2);
+            router.OutboundConnection(remoteAddress, PubsubRouter.GossipsubProtocolVersionV12, setup.connection.Task, setup.SentRpcs.Add);
+            router.OnRpc(setup.RemotePeerId, new Rpc().WithTopics([topic], []));
+            setup.SentRpcs.Clear();
+            return setup;
+        }
+
+        public MessageId Publish(byte[] data)
+        {
+            Router.Publish(Topic, data);
+            Message published = SentRpcs.Last().Publish.Single();
+            return PubsubSettings.ConcatFromAndSeqno(published);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            connection.TrySetResult();
+            cancellation.Cancel();
+            cancellation.Dispose();
+            Router.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
@@ -90,9 +90,9 @@ public class GossipsubControlLimitsTests
         MessageId messageId = setup.Publish([1, 2, 3]);
         setup.SentRpcs.Clear();
 
-        Rpc dontWant = new() { Control = new ControlMessage() };
-        dontWant.Control.Idontwant.Add(new ControlIDontWant { MessageIDs = { ByteString.CopyFrom(messageId.Bytes) } });
-        setup.Router.OnRpc(setup.RemotePeerId, dontWant);
+        Rpc unwanted = new() { Control = new ControlMessage() };
+        unwanted.Control.Idontwant.Add(new ControlIDontWant { MessageIDs = { ByteString.CopyFrom(messageId.Bytes) } });
+        setup.Router.OnRpc(setup.RemotePeerId, unwanted);
         setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(messageId));
         Assert.That(GetPublishedMessages(setup.SentRpcs), Is.Empty);
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
@@ -194,6 +194,24 @@ public class GossipsubControlLimitsTests
     }
 
     [Test]
+    public void IwantPromises_RefreshExistingDeadlines()
+    {
+        IwantPromiseTracker tracker = new(maxPromises: 1);
+        PeerId peer = TestPeers.PeerId(1);
+        MessageId message = new([1]);
+        DateTime now = DateTime.UtcNow;
+
+        tracker.Add(peer, [message], now.AddSeconds(-1));
+        tracker.Add(peer, [message], now.AddSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tracker.Count, Is.EqualTo(1));
+            Assert.That(tracker.TakeExpired(now), Is.Empty);
+        });
+    }
+
+    [Test]
     public async Task ThrottledMessages_ClearOutstandingIwantPromises()
     {
         await using RouterSetup setup = await RouterSetup.Create(new PubsubSettings { HeartbeatInterval = int.MaxValue });

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
@@ -19,10 +19,12 @@ public class GossipsubControlLimitsTests
         {
             HeartbeatInterval = int.MaxValue,
             MaxIHaveMessages = 1,
-            MaxIHaveLength = 2,
+            MaxIHaveLength = 3,
         });
 
-        setup.Router.OnRpc(setup.RemotePeerId, CreateIhave(setup.Topic, [1], [2], [3]));
+        Rpc ihaves = CreateIhave(setup.Topic, [1], [2]);
+        ihaves.Control.Ihave.Add(new ControlIHave { TopicID = setup.Topic, MessageIDs = { ByteString.CopyFrom([3]) } });
+        setup.Router.OnRpc(setup.RemotePeerId, ihaves);
 
         Assert.That(GetIwantIds(setup.SentRpcs), Has.Count.EqualTo(2));
         setup.SentRpcs.Clear();
@@ -64,7 +66,21 @@ public class GossipsubControlLimitsTests
     }
 
     [Test]
-    public async Task Idontwant_SuppressesResponsesUntilItsHeartbeatTtlExpires()
+    public async Task Iwant_ResponseLimitIncludesProtobufEnvelopeOverhead()
+    {
+        PubsubSettings settings = new() { HeartbeatInterval = int.MaxValue };
+        await using RouterSetup setup = await RouterSetup.Create(settings);
+        MessageId messageId = setup.Publish([1, 2, 3]);
+        settings.MaxIwantResponseBytes = setup.SentRpcs.Last().Publish.Single().CalculateSize();
+        setup.SentRpcs.Clear();
+
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(messageId));
+
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Is.Empty);
+    }
+
+    [Test]
+    public async Task IDontWant_SuppressesResponsesUntilItsHeartbeatTtlExpires()
     {
         await using RouterSetup setup = await RouterSetup.Create(new PubsubSettings
         {

--- a/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub.Tests/GossipsubControlLimitsTests.cs
@@ -104,6 +104,72 @@ public class GossipsubControlLimitsTests
     }
 
     [Test]
+    public async Task IDontWant_SeparatesEnvelopeAndMessageIdLimits()
+    {
+        await using RouterSetup setup = await RouterSetup.Create(new PubsubSettings
+        {
+            HeartbeatInterval = int.MaxValue,
+            MaxIdontwantMessages = 1,
+            MaxIdontwantLength = 1,
+        });
+        MessageId first = setup.Publish([1]);
+        MessageId second = setup.Publish([2]);
+        MessageId third = setup.Publish([3]);
+        setup.SentRpcs.Clear();
+
+        Rpc unwanted = new() { Control = new ControlMessage() };
+        unwanted.Control.Idontwant.Add(new ControlIDontWant
+        {
+            MessageIDs = { ByteString.CopyFrom(first.Bytes), ByteString.CopyFrom(second.Bytes) },
+        });
+        unwanted.Control.Idontwant.Add(new ControlIDontWant { MessageIDs = { ByteString.CopyFrom(third.Bytes) } });
+        setup.Router.OnRpc(setup.RemotePeerId, unwanted);
+
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(first));
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Is.Empty);
+
+        setup.SentRpcs.Clear();
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(second));
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Has.Count.EqualTo(1));
+
+        setup.SentRpcs.Clear();
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(third));
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task EmptyIwantAndIdontwantEnvelopesDoNotBypassTheEnvelopeLimits()
+    {
+        await using RouterSetup setup = await RouterSetup.Create(new PubsubSettings
+        {
+            HeartbeatInterval = int.MaxValue,
+            MaxIwantMessages = 2,
+            MaxIdontwantMessages = 2,
+        });
+        MessageId iwantMessageId = setup.Publish([1]);
+        MessageId idontwantMessageId = setup.Publish([2]);
+        setup.SentRpcs.Clear();
+
+        Rpc iwant = new() { Control = new ControlMessage() };
+        iwant.Control.Iwant.Add(new ControlIWant());
+        iwant.Control.Iwant.Add(new ControlIWant());
+        iwant.Control.Iwant.Add(new ControlIWant { MessageIDs = { ByteString.CopyFrom(iwantMessageId.Bytes) } });
+        setup.Router.OnRpc(setup.RemotePeerId, iwant);
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Is.Empty);
+
+        await setup.Router.Heartbeat();
+        setup.SentRpcs.Clear();
+
+        Rpc idontwant = new() { Control = new ControlMessage() };
+        idontwant.Control.Idontwant.Add(new ControlIDontWant());
+        idontwant.Control.Idontwant.Add(new ControlIDontWant());
+        idontwant.Control.Idontwant.Add(new ControlIDontWant { MessageIDs = { ByteString.CopyFrom(idontwantMessageId.Bytes) } });
+        setup.Router.OnRpc(setup.RemotePeerId, idontwant);
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIwant(idontwantMessageId));
+        Assert.That(GetPublishedMessages(setup.SentRpcs), Has.Count.EqualTo(1));
+    }
+
+    [Test]
     public void IwantPromises_AreBoundedAndFulfilledByTheMessageId()
     {
         IwantPromiseTracker tracker = new(maxPromises: 1);
@@ -125,6 +191,23 @@ public class GossipsubControlLimitsTests
         tracker.Add(firstPeer, [firstMessage], DateTime.UtcNow.AddSeconds(1));
         tracker.Fulfill(firstMessage);
         Assert.That(tracker.Count, Is.Zero);
+    }
+
+    [Test]
+    public async Task ThrottledMessages_ClearOutstandingIwantPromises()
+    {
+        await using RouterSetup setup = await RouterSetup.Create(new PubsubSettings { HeartbeatInterval = int.MaxValue });
+        Identity author = TestPeers.Identity(3);
+        Message message = new Rpc().WithMessages(setup.Topic, 1, author.PeerId.Bytes, [1], author).Publish.Single();
+        MessageId messageId = PubsubSettings.ConcatFromAndSeqno(message);
+
+        setup.Router.OnRpc(setup.RemotePeerId, CreateIhave(setup.Topic, messageId.Bytes));
+        Assert.That(setup.Router.IwantPromiseCount, Is.EqualTo(1));
+
+        setup.Router.VerifyMessage = _ => MessageValidity.Throttled;
+        setup.Router.OnRpc(setup.RemotePeerId, new Rpc { Publish = { message } });
+
+        Assert.That(setup.Router.IwantPromiseCount, Is.Zero);
     }
 
     [TestCase(0, 1, 1, 1, 1, 1, 1, 1)]
@@ -155,6 +238,21 @@ public class GossipsubControlLimitsTests
             IWantFollowupTime = followupTime,
             IdontwantTtlHeartbeats = idontwantTtl,
             MaxIdontwantMessages = maxIdontwantMessages,
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PubsubRouter(new PeerStore(), settings));
+    }
+
+    [TestCase(0, 1, 1)]
+    [TestCase(1, 0, 1)]
+    [TestCase(1, 1, 0)]
+    public void Router_RejectsInvalidControlEnvelopeLimits(int maxIwantMessages, int maxIwantLength, int maxIdontwantLength)
+    {
+        PubsubSettings settings = new()
+        {
+            MaxIwantMessages = maxIwantMessages,
+            MaxIwantLength = maxIwantLength,
+            MaxIdontwantLength = maxIdontwantLength,
         };
 
         Assert.Throws<ArgumentOutOfRangeException>(() => new PubsubRouter(new PeerStore(), settings));

--- a/src/libp2p/Libp2p.Protocols.Pubsub/IwantPromiseTracker.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/IwantPromiseTracker.cs
@@ -46,15 +46,19 @@ internal sealed class IwantPromiseTracker
                 promises.Add(id, byPeer);
             }
 
-            if (!byPeer.ContainsKey(peerId) && promiseCount >= maxPromises)
+            if (byPeer.ContainsKey(peerId))
+            {
+                byPeer[peerId] = deadline;
+                return;
+            }
+
+            if (promiseCount >= maxPromises)
             {
                 return;
             }
 
-            if (byPeer.TryAdd(peerId, deadline))
-            {
-                promiseCount++;
-            }
+            byPeer.Add(peerId, deadline);
+            promiseCount++;
         }
     }
 

--- a/src/libp2p/Libp2p.Protocols.Pubsub/IwantPromiseTracker.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/IwantPromiseTracker.cs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Nethermind.Libp2p.Core;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub;
+
+/// <summary>
+/// Tracks a bounded random sample of message promises created by IHAVE/IWANT.
+/// </summary>
+internal sealed class IwantPromiseTracker
+{
+    private readonly object sync = new();
+    private readonly Dictionary<MessageId, Dictionary<PeerId, DateTime>> promises = [];
+    private readonly int maxPromises;
+    private int promiseCount;
+
+    public IwantPromiseTracker(int maxPromises)
+    {
+        if (maxPromises <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxPromises));
+        }
+
+        this.maxPromises = maxPromises;
+    }
+
+    public void Add(PeerId peerId, IReadOnlyList<MessageId> messageIds, DateTime deadline)
+    {
+        if (messageIds.Count == 0)
+        {
+            return;
+        }
+
+        MessageId id = messageIds[Random.Shared.Next(messageIds.Count)];
+        lock (sync)
+        {
+            if (!promises.TryGetValue(id, out Dictionary<PeerId, DateTime>? byPeer))
+            {
+                if (promiseCount >= maxPromises)
+                {
+                    return;
+                }
+
+                byPeer = [];
+                promises.Add(id, byPeer);
+            }
+
+            if (!byPeer.ContainsKey(peerId) && promiseCount >= maxPromises)
+            {
+                return;
+            }
+
+            if (byPeer.TryAdd(peerId, deadline))
+            {
+                promiseCount++;
+            }
+        }
+    }
+
+    public void Fulfill(MessageId id)
+    {
+        lock (sync)
+        {
+            if (promises.Remove(id, out Dictionary<PeerId, DateTime>? byPeer))
+            {
+                promiseCount -= byPeer.Count;
+            }
+        }
+    }
+
+    public IReadOnlyDictionary<PeerId, int> TakeExpired(DateTime now)
+    {
+        lock (sync)
+        {
+            Dictionary<PeerId, int> broken = [];
+            foreach ((MessageId id, Dictionary<PeerId, DateTime> byPeer) in promises.ToArray())
+            {
+                foreach ((PeerId peerId, DateTime deadline) in byPeer.ToArray())
+                {
+                    if (deadline > now)
+                    {
+                        continue;
+                    }
+
+                    byPeer.Remove(peerId);
+                    promiseCount--;
+                    broken[peerId] = broken.GetValueOrDefault(peerId) + 1;
+                }
+
+                if (byPeer.Count == 0)
+                {
+                    promises.Remove(id);
+                }
+            }
+
+            return broken;
+        }
+    }
+
+    public void Clear(PeerId peerId)
+    {
+        lock (sync)
+        {
+            foreach ((MessageId id, Dictionary<PeerId, DateTime> byPeer) in promises.ToArray())
+            {
+                if (!byPeer.Remove(peerId))
+                {
+                    continue;
+                }
+
+                promiseCount--;
+                if (byPeer.Count == 0)
+                {
+                    promises.Remove(id);
+                }
+            }
+        }
+    }
+
+    internal int Count
+    {
+        get
+        {
+            lock (sync)
+            {
+                return promiseCount;
+            }
+        }
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PeerControlState.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PeerControlState.cs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Nethermind.Libp2p.Core;
+
+namespace Nethermind.Libp2p.Protocols.Pubsub;
+
+/// <summary>
+/// Bounded per-peer state for Gossipsub control messages.
+/// </summary>
+internal sealed class PeerControlState
+{
+    private readonly Dictionary<MessageId, long> unwanted = [];
+    private readonly Dictionary<MessageId, ResponseState> iwantResponses = [];
+
+    private readonly record struct ResponseState(int Count, long ExpiresAtTick);
+
+    public int IHaveMessages { get; private set; }
+    public int IHaveRequested { get; private set; }
+    public int IdontwantMessages { get; private set; }
+
+    public bool TryAcceptIHave(int maxMessages)
+    {
+        if (IHaveMessages >= maxMessages)
+        {
+            return false;
+        }
+
+        IHaveMessages++;
+        return true;
+    }
+
+    public int ReserveIHaveRequests(int requested, int maxRequests)
+    {
+        int reserved = Math.Min(requested, maxRequests - IHaveRequested);
+        IHaveRequested += reserved;
+        return reserved;
+    }
+
+    public bool TryAcceptIdontwant(int maxMessages)
+    {
+        if (IdontwantMessages >= maxMessages)
+        {
+            return false;
+        }
+
+        IdontwantMessages++;
+        return true;
+    }
+
+    public void AddUnwanted(MessageId id, long expiresAtTick, int maxEntries)
+    {
+        if (unwanted.ContainsKey(id) || unwanted.Count < maxEntries)
+        {
+            unwanted[id] = expiresAtTick;
+        }
+    }
+
+    public bool IsUnwanted(MessageId id) => unwanted.ContainsKey(id);
+
+    public bool TryRecordIwantResponse(MessageId id, long currentTick, int historyLength, int maxResponses, int maxTrackedMessages)
+    {
+        if (iwantResponses.TryGetValue(id, out ResponseState response))
+        {
+            if (response.Count >= maxResponses)
+            {
+                return false;
+            }
+
+            iwantResponses[id] = response with { Count = response.Count + 1 };
+            return true;
+        }
+
+        if (iwantResponses.Count >= maxTrackedMessages)
+        {
+            return false;
+        }
+
+        iwantResponses[id] = new ResponseState(1, currentTick + historyLength);
+        return true;
+    }
+
+    public void ResetHeartbeatCounters(long currentTick)
+    {
+        IHaveMessages = 0;
+        IHaveRequested = 0;
+        IdontwantMessages = 0;
+        RemoveExpired(unwanted, currentTick);
+        RemoveExpired(iwantResponses, currentTick);
+    }
+
+    private static void RemoveExpired(Dictionary<MessageId, long> entries, long currentTick)
+    {
+        List<MessageId>? expired = null;
+        foreach ((MessageId id, long expiresAtTick) in entries)
+        {
+            if (expiresAtTick <= currentTick)
+            {
+                (expired ??= []).Add(id);
+            }
+        }
+
+        if (expired is not null)
+        {
+            foreach (MessageId id in expired)
+            {
+                entries.Remove(id);
+            }
+        }
+    }
+
+    private static void RemoveExpired(Dictionary<MessageId, ResponseState> entries, long currentTick)
+    {
+        List<MessageId>? expired = null;
+        foreach ((MessageId id, ResponseState response) in entries)
+        {
+            if (response.ExpiresAtTick <= currentTick)
+            {
+                (expired ??= []).Add(id);
+            }
+        }
+
+        if (expired is not null)
+        {
+            foreach (MessageId id in expired)
+            {
+                entries.Remove(id);
+            }
+        }
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PeerControlState.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PeerControlState.cs
@@ -17,6 +17,7 @@ internal sealed class PeerControlState
 
     public int IHaveMessages { get; private set; }
     public int IHaveRequested { get; private set; }
+    public int IwantMessages { get; private set; }
     public int IdontwantMessages { get; private set; }
 
     public bool TryAcceptIHave(int maxMessages)
@@ -45,6 +46,17 @@ internal sealed class PeerControlState
         }
 
         IdontwantMessages++;
+        return true;
+    }
+
+    public bool TryAcceptIwant(int maxMessages)
+    {
+        if (IwantMessages >= maxMessages)
+        {
+            return false;
+        }
+
+        IwantMessages++;
         return true;
     }
 
@@ -84,6 +96,7 @@ internal sealed class PeerControlState
     {
         IHaveMessages = 0;
         IHaveRequested = 0;
+        IwantMessages = 0;
         IdontwantMessages = 0;
         RemoveExpired(unwanted, currentTick);
         RemoveExpired(iwantResponses, currentTick);

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -59,6 +59,29 @@ public class PubsubSettings
         }
     }
     public SignaturePolicy DefaultSignaturePolicy { get; set; } = SignaturePolicy.StrictSign;
+
+    /// <summary>Maximum IHAVE envelopes accepted from one peer during a heartbeat.</summary>
+    public int MaxIHaveMessages { get; set; } = 10;
+
+    /// <summary>Maximum message IDs accepted from, or requested from, one peer during a heartbeat.</summary>
+    public int MaxIHaveLength { get; set; } = 5_000;
+
+    /// <summary>Maximum responses to the same IWANT message ID for one peer while it is cached.</summary>
+    public int GossipRetransmission { get; set; } = 3;
+
+    /// <summary>Maximum serialized bytes returned in response to a single IWANT RPC.</summary>
+    public int MaxIwantResponseBytes { get; set; } = 512 * 1024;
+
+    /// <summary>Maximum outstanding sampled promises from IHAVE advertisements.</summary>
+    public int MaxIwantPromises { get; set; } = 10_000;
+
+    /// <summary>Time after which a sampled IHAVE promise is penalized when its message never arrives.</summary>
+    public int IWantFollowupTime { get; set; } = 3_000;
+
+    /// <summary>Number of heartbeats for which accepted IDONTWANT IDs suppress IWANT responses.</summary>
+    public int IdontwantTtlHeartbeats { get; set; } = 3;
+
+    /// <summary>Maximum IDONTWANT message IDs accepted from one peer during a heartbeat.</summary>
     public int MaxIdontwantMessages { get; set; } = 50;
 
     /// <summary>

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubSubSettings.cs
@@ -66,6 +66,12 @@ public class PubsubSettings
     /// <summary>Maximum message IDs accepted from, or requested from, one peer during a heartbeat.</summary>
     public int MaxIHaveLength { get; set; } = 5_000;
 
+    /// <summary>Maximum IWANT envelopes accepted from one peer during a heartbeat.</summary>
+    public int MaxIwantMessages { get; set; } = 10;
+
+    /// <summary>Maximum message IDs accepted from one peer through IWANT during a heartbeat.</summary>
+    public int MaxIwantLength { get; set; } = 5_000;
+
     /// <summary>Maximum responses to the same IWANT message ID for one peer while it is cached.</summary>
     public int GossipRetransmission { get; set; } = 3;
 
@@ -81,8 +87,11 @@ public class PubsubSettings
     /// <summary>Number of heartbeats for which accepted IDONTWANT IDs suppress IWANT responses.</summary>
     public int IdontwantTtlHeartbeats { get; set; } = 3;
 
-    /// <summary>Maximum IDONTWANT message IDs accepted from one peer during a heartbeat.</summary>
-    public int MaxIdontwantMessages { get; set; } = 50;
+    /// <summary>Maximum IDONTWANT envelopes accepted from one peer during a heartbeat.</summary>
+    public int MaxIdontwantMessages { get; set; } = 1_000;
+
+    /// <summary>Maximum message IDs accepted from one IDONTWANT envelope.</summary>
+    public int MaxIdontwantLength { get; set; } = 10;
 
     /// <summary>
     /// Enables the opt-in Gossipsub v1.3 Partial Messages extension. The router

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -529,7 +529,10 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             }
 
             int messageSize = message.CalculateSize();
-            if (responseBytes + messageSize > _settings.MaxIwantResponseBytes)
+            int serializedMessageSize = CodedOutputStream.ComputeTagSize(Rpc.PublishFieldNumber)
+                + CodedOutputStream.ComputeLengthSize(messageSize)
+                + messageSize;
+            if (responseBytes + serializedMessageSize > _settings.MaxIwantResponseBytes)
             {
                 continue;
             }
@@ -537,7 +540,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             if (peer.Control.TryRecordIwantResponse(messageId, heartbeatTick, _settings.mcache_len, _settings.GossipRetransmission, _settings.MaxIHaveLength))
             {
                 messages.Add(message);
-                responseBytes += messageSize;
+                responseBytes += serializedMessageSize;
             }
         }
         if (messages.Any())

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -198,6 +198,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                     _iwantPromises.Fulfill(messageId);
                     continue;
                 case MessageValidity.Throttled:
+                    _iwantPromises.Clear(peerId);
                     continue;
             }
 
@@ -484,7 +485,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             return;
         }
 
-        MessageId[] selected = messageIds.OrderBy(_ => Random.Shared.Next()).Take(requested).ToArray();
+        MessageId[] selected = SampleMessageIds(messageIds, requested);
         ControlIWant iwant = new();
         iwant.MessageIDs.AddRange(selected.Select(messageId => ByteString.CopyFrom(messageId.Bytes)));
         peerMessages.GetOrAdd(peerId, _ => new Rpc())
@@ -500,12 +501,18 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             return;
         }
 
+        PeerControlState control = peer.Control;
         HashSet<MessageId> requested = [];
         foreach (ControlIWant iwant in iwants)
         {
+            if (!control.TryAcceptIwant(_settings.MaxIwantMessages))
+            {
+                break;
+            }
+
             foreach (ByteString idBytes in iwant.MessageIDs)
             {
-                if (requested.Count >= _settings.MaxIHaveLength)
+                if (requested.Count >= _settings.MaxIwantLength)
                 {
                     break;
                 }
@@ -513,7 +520,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 requested.Add(new MessageId(idBytes.ToByteArray()));
             }
 
-            if (requested.Count >= _settings.MaxIHaveLength)
+            if (requested.Count >= _settings.MaxIwantLength)
             {
                 break;
             }
@@ -537,7 +544,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 continue;
             }
 
-            if (peer.Control.TryRecordIwantResponse(messageId, heartbeatTick, _settings.mcache_len, _settings.GossipRetransmission, _settings.MaxIHaveLength))
+            if (control.TryRecordIwantResponse(messageId, heartbeatTick, _settings.mcache_len, _settings.GossipRetransmission, _settings.MaxIwantLength))
             {
                 messages.Add(message);
                 responseBytes += serializedMessageSize;
@@ -558,18 +565,43 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         }
 
         PeerControlState control = peer.Control;
-        int maxUnwanted = (int)Math.Min((long)_settings.MaxIdontwantMessages * _settings.IdontwantTtlHeartbeats, int.MaxValue);
+        int maxUnwanted = (int)Math.Min(
+            (long)_settings.MaxIdontwantMessages * _settings.MaxIdontwantLength * _settings.IdontwantTtlHeartbeats,
+            int.MaxValue);
         foreach (ControlIDontWant idontwant in idontwants)
         {
-            foreach (ByteString idBytes in idontwant.MessageIDs)
+            if (!control.TryAcceptIdontwant(_settings.MaxIdontwantMessages))
             {
-                if (!control.TryAcceptIdontwant(_settings.MaxIdontwantMessages))
-                {
-                    return;
-                }
+                break;
+            }
 
+            foreach (ByteString idBytes in idontwant.MessageIDs.Take(_settings.MaxIdontwantLength))
+            {
                 control.AddUnwanted(new MessageId(idBytes.ToByteArray()), heartbeatTick + _settings.IdontwantTtlHeartbeats, maxUnwanted);
             }
         }
+    }
+
+    private static MessageId[] SampleMessageIds(IEnumerable<MessageId> messageIds, int count)
+    {
+        List<MessageId> sample = new(count);
+        int candidates = 0;
+        foreach (MessageId messageId in messageIds)
+        {
+            candidates++;
+            if (sample.Count < count)
+            {
+                sample.Add(messageId);
+                continue;
+            }
+
+            int replacementIndex = Random.Shared.Next(candidates);
+            if (replacementIndex < count)
+            {
+                sample[replacementIndex] = messageId;
+            }
+        }
+
+        return sample.ToArray();
     }
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.Rpc.cs
@@ -190,10 +190,12 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             {
                 case MessageValidity.Rejected:
                     _limboMessageCache.Add(messageId);
+                    _iwantPromises.Fulfill(messageId);
                     RecordMessageDelivery(peerId, message, message.Topic, false);  // Track invalid message
                     continue;
                 case MessageValidity.Ignored:
                     _limboMessageCache.Add(messageId);
+                    _iwantPromises.Fulfill(messageId);
                     continue;
                 case MessageValidity.Throttled:
                     continue;
@@ -208,6 +210,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
             _seenMessages.Add(messageId);
             _messageCache.Put(messageId, message);
+            _iwantPromises.Fulfill(messageId);
 
             // Record valid message delivery for scoring
             RecordMessageDelivery(peerId, message, message.Topic, true);
@@ -432,36 +435,109 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
     private void HandleIhave(PeerId peerId, IEnumerable<ControlIHave> ihaves, ConcurrentDictionary<PeerId, Rpc> peerMessages)
     {
-        List<MessageId> messageIds = [];
-
-        foreach (ControlIHave? ihave in ihaves.Where(iw => topicState.GetValueOrDefault(iw.TopicID)?.IsSubscribed is true))
+        if (GetPeerScore(peerId) < _settings.GossipThreshold || !peerState.TryGetValue(peerId, out PubsubPeer? peer) || !peer.IsGossipSub)
         {
-            messageIds.AddRange(ihave.MessageIDs.Select(m => new MessageId(m.ToByteArray()))
-                .Where(mid => !_seenMessages.Contains(mid) && !_limboMessageCache.Contains(mid)));
+            return;
         }
 
-        if (messageIds.Any())
+        PeerControlState control = peer.Control;
+        if (control.IHaveRequested >= _settings.MaxIHaveLength)
         {
-            ControlIWant ciw = new();
-            foreach (MessageId mId in messageIds)
+            return;
+        }
+
+        HashSet<MessageId> messageIds = [];
+        foreach (ControlIHave ihave in ihaves)
+        {
+            if (!control.TryAcceptIHave(_settings.MaxIHaveMessages))
             {
-                ciw.MessageIDs.Add(ByteString.CopyFrom(mId.Bytes));
+                break;
             }
-            peerMessages.GetOrAdd(peerId, _ => new Rpc())
-                .Ensure(r => r.Control.Iwant)
-                .Add(ciw);
+
+            if (!mesh.ContainsKey(ihave.TopicID))
+            {
+                continue;
+            }
+
+            foreach (ByteString idBytes in ihave.MessageIDs.Take(_settings.MaxIHaveLength))
+            {
+                MessageId messageId = new(idBytes.ToByteArray());
+                if (!_seenMessages.Contains(messageId) && !_limboMessageCache.Contains(messageId))
+                {
+                    messageIds.Add(messageId);
+                    if (messageIds.Count == _settings.MaxIHaveLength)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (messageIds.Count == _settings.MaxIHaveLength)
+            {
+                break;
+            }
         }
+
+        int requested = control.ReserveIHaveRequests(messageIds.Count, _settings.MaxIHaveLength);
+        if (requested == 0)
+        {
+            return;
+        }
+
+        MessageId[] selected = messageIds.OrderBy(_ => Random.Shared.Next()).Take(requested).ToArray();
+        ControlIWant iwant = new();
+        iwant.MessageIDs.AddRange(selected.Select(messageId => ByteString.CopyFrom(messageId.Bytes)));
+        peerMessages.GetOrAdd(peerId, _ => new Rpc())
+            .Ensure(r => r.Control.Iwant)
+            .Add(iwant);
+        _iwantPromises.Add(peerId, selected, DateTime.UtcNow.AddMilliseconds(_settings.IWantFollowupTime));
     }
 
     private void HandleIwant(PeerId peerId, IEnumerable<ControlIWant> iwants, ConcurrentDictionary<PeerId, Rpc> peerMessages)
     {
-        IEnumerable<MessageId> messageIds = iwants.SelectMany(iw => iw.MessageIDs).Select(m => new MessageId(m.ToByteArray()));
-        List<Message> messages = [];
-        foreach (MessageId mId in messageIds)
+        if (GetPeerScore(peerId) < _settings.GossipThreshold || !peerState.TryGetValue(peerId, out PubsubPeer? peer) || !peer.IsGossipSub)
         {
-            if (_messageCache.TryGet(mId, out Message message))
+            return;
+        }
+
+        HashSet<MessageId> requested = [];
+        foreach (ControlIWant iwant in iwants)
+        {
+            foreach (ByteString idBytes in iwant.MessageIDs)
+            {
+                if (requested.Count >= _settings.MaxIHaveLength)
+                {
+                    break;
+                }
+
+                requested.Add(new MessageId(idBytes.ToByteArray()));
+            }
+
+            if (requested.Count >= _settings.MaxIHaveLength)
+            {
+                break;
+            }
+        }
+
+        List<Message> messages = [];
+        long responseBytes = 0;
+        foreach (MessageId messageId in requested)
+        {
+            if (peer.Control.IsUnwanted(messageId) || !_messageCache.TryGet(messageId, out Message message))
+            {
+                continue;
+            }
+
+            int messageSize = message.CalculateSize();
+            if (responseBytes + messageSize > _settings.MaxIwantResponseBytes)
+            {
+                continue;
+            }
+
+            if (peer.Control.TryRecordIwantResponse(messageId, heartbeatTick, _settings.mcache_len, _settings.GossipRetransmission, _settings.MaxIHaveLength))
             {
                 messages.Add(message);
+                responseBytes += messageSize;
             }
         }
         if (messages.Any())
@@ -473,9 +549,24 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
     private void HandleIdontwant(PeerId peerId, IEnumerable<ControlIDontWant> idontwants)
     {
-        foreach (MessageId messageId in idontwants.SelectMany(iw => iw.MessageIDs).Select(m => new MessageId(m.ToByteArray())).Take(_settings.MaxIdontwantMessages))
+        if (!peerState.TryGetValue(peerId, out PubsubPeer? peer) || peer.Protocol < PubsubPeer.PubsubProtocol.GossipsubV12)
         {
-            _idontwantMessages.Add((peerId, messageId));
+            return;
+        }
+
+        PeerControlState control = peer.Control;
+        int maxUnwanted = (int)Math.Min((long)_settings.MaxIdontwantMessages * _settings.IdontwantTtlHeartbeats, int.MaxValue);
+        foreach (ControlIDontWant idontwant in idontwants)
+        {
+            foreach (ByteString idBytes in idontwant.MessageIDs)
+            {
+                if (!control.TryAcceptIdontwant(_settings.MaxIdontwantMessages))
+                {
+                    return;
+                }
+
+                control.AddUnwanted(new MessageId(idBytes.ToByteArray()), heartbeatTick + _settings.IdontwantTtlHeartbeats, maxUnwanted);
+            }
         }
     }
 }

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -463,13 +463,17 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     private static void ValidateControlSettings(PubsubSettings settings)
     {
         if (settings.MaxIHaveMessages <= 0 || settings.MaxIHaveLength <= 0 ||
+            settings.MaxIwantMessages <= 0 || settings.MaxIwantLength <= 0 ||
             settings.GossipRetransmission <= 0 || settings.MaxIwantResponseBytes <= 0 ||
             settings.MaxIwantPromises <= 0 || settings.IWantFollowupTime <= 0 ||
-            settings.IdontwantTtlHeartbeats <= 0 || settings.MaxIdontwantMessages <= 0)
+            settings.IdontwantTtlHeartbeats <= 0 || settings.MaxIdontwantMessages <= 0 ||
+            settings.MaxIdontwantLength <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(settings), "Gossipsub control limits must be positive.");
         }
     }
+
+    internal int IwantPromiseCount => _iwantPromises.Count;
 
     public Task Heartbeat()
     {

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -52,6 +52,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
             Backoff = [];
             SendRpcQueue = new ConcurrentQueue<Rpc>();
             Score = new PeerScore(settings);
+            Control = new PeerControlState();
         }
 
         public enum PubsubProtocol
@@ -194,6 +195,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
         // Peer scoring (Gossipsub v1.1)
         public PeerScore Score { get; internal set; }
+        public PeerControlState Control { get; }
     }
 
     private static readonly CancellationToken Canceled;
@@ -230,8 +232,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     private readonly MessageCache _messageCache;
     private readonly TtlCache<MessageId> _seenMessages;
     private readonly TtlCache<MessageId> _limboMessageCache;
-    private readonly TtlCache<(PeerId, MessageId)> _idontwantMessages;
     private readonly PartialMessageGossipCache partialMessageGossip;
+    private readonly IwantPromiseTracker _iwantPromises;
 
     private ILocalPeer? localPeer;
     private readonly ILogger? logger;
@@ -256,6 +258,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     private readonly PeerStore _peerStore;
     private readonly IReadOnlyDictionary<PeerId, Multiaddress[]> directPeers;
     private DateTime nextDirectConnectionAttempt;
+    private long heartbeatTick;
     private ulong seqNo = 1;
 
     private record Reconnection(Multiaddress[] Addresses, int Attempts);
@@ -284,10 +287,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         }
 
         directPeers = CreateDirectPeers(_settings.DirectPeers);
+        ValidateControlSettings(_settings);
         _messageCache = new(_settings.mcache_gossip, _settings.mcache_len, _settings.MaxMessageCacheEntries, _settings.MaxMessageCacheBytes);
         _seenMessages = new(_settings.MessageCacheTtl, _settings.MaxSeenMessageIds);
         _limboMessageCache = new(_settings.MessageCacheTtl, _settings.MaxSeenMessageIds);
-        _idontwantMessages = new(_settings.MessageCacheTtl);
+        _iwantPromises = new(_settings.MaxIwantPromises);
         partialMessageGossip = new(_settings.MaxPartialMessageGroupsPerTopic, _settings.PartialMessageGossipTtlHeartbeats);
     }
 
@@ -397,7 +401,6 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         _messageCache.Clear();
         _seenMessages.Dispose();
         _limboMessageCache.Dispose();
-        _idontwantMessages.Dispose();
     }
 
     private void Reconnect(CancellationToken token)
@@ -457,6 +460,17 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         return directPeers.Keys.Where(peerId => IsDirectPeerSubscribedTo(peerId, topic));
     }
 
+    private static void ValidateControlSettings(PubsubSettings settings)
+    {
+        if (settings.MaxIHaveMessages <= 0 || settings.MaxIHaveLength <= 0 ||
+            settings.GossipRetransmission <= 0 || settings.MaxIwantResponseBytes <= 0 ||
+            settings.MaxIwantPromises <= 0 || settings.IWantFollowupTime <= 0 ||
+            settings.IdontwantTtlHeartbeats <= 0 || settings.MaxIdontwantMessages <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(settings), "Gossipsub control limits must be positive.");
+        }
+    }
+
     public Task Heartbeat()
     {
         // Apply score decay
@@ -467,6 +481,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         Action<string, byte[], IReadOnlyList<PeerId>>? onPartialGossip = OnPartialGossip;
         lock (this)
         {
+            foreach ((PeerId peerId, int brokenPromises) in _iwantPromises.TakeExpired(DateTime.UtcNow))
+            {
+                ApplyBehaviorPenalty(peerId, brokenPromises);
+            }
+
             // First, prune peers with negative scores from all meshes (Gossipsub v1.1)
             foreach (KeyValuePair<string, HashSet<PeerId>> meshEntry in mesh)
             {
@@ -655,6 +674,11 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
             partialMessageGossip.Heartbeat();
             _messageCache.Shift();
+            heartbeatTick++;
+            foreach (PubsubPeer peer in peerState.Values)
+            {
+                peer.Control.ResetHeartbeatCounters(heartbeatTick);
+            }
         }
 
         foreach (KeyValuePair<PeerId, Rpc> peerMessage in peerMessages)
@@ -701,6 +725,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
 
             dialTask.ContinueWith(t =>
             {
+                _iwantPromises.Clear(peerId);
                 peerState.GetValueOrDefault(peerId)?.TokenSource.Cancel();
                 peerState.TryRemove(peerId, out _);
                 foreach (KeyValuePair<string, HashSet<PeerId>> topicPeers in fPeers)
@@ -764,6 +789,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
                 logger?.LogDebug("Inbound, let's dial {peerId} via remotely initiated connection", peerId);
                 listTask.ContinueWith(t =>
                 {
+                    _iwantPromises.Clear(peerId);
                     peerState.GetValueOrDefault(peerId)?.TokenSource.Cancel();
                     peerState.TryRemove(peerId, out _);
                     foreach (KeyValuePair<string, HashSet<PeerId>> topicPeers in fPeers)


### PR DESCRIPTION
## Summary
- cap IHAVE intake and IWANT responses, including retransmission and byte limits
- honor bounded, expiring IDONTWANT state for v1.2 peers
- track a bounded random sample of IHAVE promises for behavioral penalties

## Validation
- Pubsub protocol unit tests