### PR TITLE
Expose sessions through ILocalPeer

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -26,7 +26,7 @@ ISession session = await peer.DialAsync(remoteAddress);
 
 ## Inspecting current sessions
 
-`ILocalPeer.Sessions` is a peer-owned, live read-only view of the current sessions:
+`ILocalPeer.Sessions` is a stable, peer-owned live view of the current sessions. It exposes no collection mutation APIs:
 
 ```csharp
 IReadOnlyCollection<ISession> sessions = peer.Sessions;
@@ -37,7 +37,9 @@ foreach (ISession currentSession in sessions.ToArray())
 }
 ```
 
-Sessions enter the view during session upgrade and leave it when disconnected. The view is not independently thread-safe, so snapshot it before enumeration when connections can change, particularly if the enumeration spans `await` calls. A session can be visible while its initialization is still in progress; use the session returned by `DialAsync` or delivered through `OnConnected` when fully initialized sessions are required.
+Sessions enter the view during session upgrade and leave it when disconnected. `Count` and each enumeration are synchronized with those lifecycle changes; each enumeration uses a point-in-time snapshot. Calling `ToArray()` makes that snapshot explicit when subsequent work spans `await` calls. Later `Count` calls and enumerations reflect the latest sessions, while an existing enumeration or array remains unchanged.
+
+A session can be visible while its initialization is still in progress; use the session returned by `DialAsync` or delivered through `OnConnected` when fully initialized sessions are required.
 
 ## Dialing application protocols
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -24,6 +24,21 @@ ISession session = await peer.DialAsync(remoteAddress);
 
 `ILocalPeer.DialAsync` establishes the lower stack first: transport connection, protocol negotiation, encryption or authentication, and stream multiplexing. Once the session exists, application protocols can be opened over it.
 
+## Inspecting current sessions
+
+`ILocalPeer.Sessions` is a peer-owned, live read-only view of the current sessions:
+
+```csharp
+IReadOnlyCollection<ISession> sessions = peer.Sessions;
+
+foreach (ISession currentSession in sessions.ToArray())
+{
+    Console.WriteLine($"Connected to {currentSession.RemoteAddress}");
+}
+```
+
+Sessions enter the view during session upgrade and leave it when disconnected. The view is not independently thread-safe, so snapshot it before enumeration when connections can change, particularly if the enumeration spans `await` calls. A session can be visible while its initialization is still in progress; use the session returned by `DialAsync` or delivered through `OnConnected` when fully initialized sessions are required.
+
 ## Dialing application protocols
 
 Use `DialAsync<TProtocol>()` for protocols that do not need a request object:

--- a/src/libp2p/Libp2p.Core.Tests/LocalPeerSessionsTests.cs
+++ b/src/libp2p/Libp2p.Core.Tests/LocalPeerSessionsTests.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using System.Collections;
+using System.Collections.ObjectModel;
+
+namespace Nethermind.Libp2p.Core.Tests;
+
+internal class LocalPeerSessionsTests
+{
+    [Test]
+    public void InterfaceView_IsStableAndDoesNotExposeCollectionMutation()
+    {
+        LocalPeer peer = CreatePeer();
+        ILocalPeer interfacePeer = peer;
+
+        IReadOnlyCollection<ISession> sessions = interfacePeer.Sessions;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(interfacePeer.Sessions, Is.SameAs(sessions));
+            Assert.That(sessions, Is.Not.InstanceOf<ObservableCollection<LocalPeer.Session>>());
+            Assert.That(sessions, Is.Not.InstanceOf<ICollection<LocalPeer.Session>>());
+            Assert.That(sessions, Is.Not.InstanceOf<IList>());
+        });
+    }
+
+    [Test]
+    public void InterfaceView_EnumerationUsesPointInTimeSnapshot()
+    {
+        LocalPeer peer = CreatePeer();
+        LocalPeer.Session firstSession = new(peer);
+        LocalPeer.Session laterSession = new(peer);
+
+        lock (peer.Sessions)
+        {
+            peer.Sessions.Add(firstSession);
+        }
+
+        IReadOnlyCollection<ISession> sessions = ((ILocalPeer)peer).Sessions;
+        using IEnumerator<ISession> enumerator = sessions.GetEnumerator();
+
+        Assert.That(enumerator.MoveNext(), Is.True);
+        Assert.That(enumerator.Current, Is.SameAs(firstSession));
+
+        lock (peer.Sessions)
+        {
+            peer.Sessions.Add(laterSession);
+        }
+
+        Assert.DoesNotThrow(() => Assert.That(enumerator.MoveNext(), Is.False));
+        Assert.Multiple(() =>
+        {
+            Assert.That(sessions.Count, Is.EqualTo(2));
+            Assert.That(sessions.ToArray(), Is.EqualTo(new ISession[] { firstSession, laterSession }));
+        });
+    }
+
+    private static LocalPeer CreatePeer()
+        => new(new Identity(Enumerable.Repeat((byte)42, 32).ToArray()), null, new ProtocolStackSettings());
+}

--- a/src/libp2p/Libp2p.Core.TestsBase/LocalPeerStub.cs
+++ b/src/libp2p/Libp2p.Core.TestsBase/LocalPeerStub.cs
@@ -17,6 +17,7 @@ public class LocalPeerStub : ILocalPeer
 
     public Identity Identity { get; set; }
     public Multiaddress Address { get; set; }
+    public IReadOnlyCollection<ISession> Sessions { get; } = [];
 
     public ObservableCollection<Multiaddress> ListenAddresses => throw new NotImplementedException();
 

--- a/src/libp2p/Libp2p.Core/ILocalPeer.cs
+++ b/src/libp2p/Libp2p.Core/ILocalPeer.cs
@@ -10,6 +10,12 @@ public interface ILocalPeer : IAsyncDisposable
 {
     Identity Identity { get; }
 
+    /// <summary>
+    /// Gets the peer-owned live view of current sessions.
+    /// Sessions are registered during session upgrade and removed when disconnected.
+    /// </summary>
+    IReadOnlyCollection<ISession> Sessions { get; }
+
     Task<ISession> DialAsync(Multiaddress addr, CancellationToken token = default);
     Task<ISession> DialAsync(Multiaddress[] samePeerAddrs, CancellationToken token = default);
 

--- a/src/libp2p/Libp2p.Core/ILocalPeer.cs
+++ b/src/libp2p/Libp2p.Core/ILocalPeer.cs
@@ -11,8 +11,9 @@ public interface ILocalPeer : IAsyncDisposable
     Identity Identity { get; }
 
     /// <summary>
-    /// Gets the peer-owned live view of current sessions.
+    /// Gets the stable, peer-owned live view of current sessions.
     /// Sessions are registered during session upgrade and removed when disconnected.
+    /// Each enumeration is a point-in-time snapshot synchronized with those lifecycle updates.
     /// </summary>
     IReadOnlyCollection<ISession> Sessions { get; }
 

--- a/src/libp2p/Libp2p.Core/Peer.cs
+++ b/src/libp2p/Libp2p.Core/Peer.cs
@@ -31,6 +31,7 @@ public partial class LocalPeer(Identity identity, PeerStore? peerStore, IProtoco
     private readonly Dictionary<object, TaskCompletionSource<Multiaddress>> listenerReadyTcs = [];
     private readonly ConcurrentDictionary<PeerId, Task<ISession>> _pendingDials = new();
     public ObservableCollection<Session> Sessions { get; } = [];
+    IReadOnlyCollection<ISession> ILocalPeer.Sessions => Sessions;
 
     public override string ToString()
     {

--- a/src/libp2p/Libp2p.Core/Peer.cs
+++ b/src/libp2p/Libp2p.Core/Peer.cs
@@ -9,6 +9,7 @@ using Nethermind.Libp2p.Core.Discovery;
 using Nethermind.Libp2p.Core.Exceptions;
 using Nethermind.Libp2p.Core.Extensions;
 using Nethermind.Libp2p.Core.Metrics;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -30,8 +31,48 @@ public partial class LocalPeer(Identity identity, PeerStore? peerStore, IProtoco
 
     private readonly Dictionary<object, TaskCompletionSource<Multiaddress>> listenerReadyTcs = [];
     private readonly ConcurrentDictionary<PeerId, Task<ISession>> _pendingDials = new();
+    private IReadOnlyCollection<ISession>? _sessionsView;
     public ObservableCollection<Session> Sessions { get; } = [];
-    IReadOnlyCollection<ISession> ILocalPeer.Sessions => Sessions;
+    IReadOnlyCollection<ISession> ILocalPeer.Sessions => GetSessionsView();
+
+    private IReadOnlyCollection<ISession> GetSessionsView()
+    {
+        IReadOnlyCollection<ISession>? view = Volatile.Read(ref _sessionsView);
+        if (view is not null)
+        {
+            return view;
+        }
+
+        view = new SessionCollectionView(Sessions);
+        return Interlocked.CompareExchange(ref _sessionsView, view, null) ?? view;
+    }
+
+    private sealed class SessionCollectionView(ObservableCollection<Session> sessions) : IReadOnlyCollection<ISession>
+    {
+        public int Count
+        {
+            get
+            {
+                lock (sessions)
+                {
+                    return sessions.Count;
+                }
+            }
+        }
+
+        public IEnumerator<ISession> GetEnumerator()
+        {
+            ISession[] snapshot;
+            lock (sessions)
+            {
+                snapshot = [.. sessions];
+            }
+
+            return ((IEnumerable<ISession>)snapshot).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
     public override string ToString()
     {

--- a/src/libp2p/Libp2p.E2eTests/SessionLifecycleTests.cs
+++ b/src/libp2p/Libp2p.E2eTests/SessionLifecycleTests.cs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Multiformats.Address;
+using Nethermind.Libp2p.Core;
+using NUnit.Framework;
+
+namespace Libp2p.E2eTests;
+
+public class SessionLifecycleTests
+{
+    [Test]
+    public async Task Sessions_ReflectConnectionLifecycleThroughInterface()
+    {
+        await using SessionLifecycleE2eTestSetup test = new();
+        await test.AddPeersAsync(2);
+
+        ILocalPeer dialer = test.Peers[0];
+        ILocalPeer listener = test.Peers[1];
+        IReadOnlyCollection<ISession> outgoingSessions = dialer.Sessions;
+        IReadOnlyCollection<ISession> incomingSessions = listener.Sessions;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(outgoingSessions, Is.Empty);
+            Assert.That(incomingSessions, Is.Empty);
+        });
+
+        TaskCompletionSource<ISession> incomingSessionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        listener.OnConnected += session => incomingSessionSource.TrySetResult(session);
+
+        ISession outgoingSession = await dialer.DialAsync([.. listener.ListenAddresses]);
+        ISession incomingSession = await incomingSessionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(outgoingSessions.Single(), Is.SameAs(outgoingSession));
+            Assert.That(incomingSessions.Single(), Is.SameAs(incomingSession));
+        });
+
+        await outgoingSession.DisconnectAsync();
+
+        Assert.That(outgoingSessions, Is.Empty);
+    }
+
+    private sealed class SessionLifecycleE2eTestSetup : E2eTestSetup
+    {
+        protected override Multiaddress[]? GetListenAddresses(int index)
+            => [$"/ip4/127.0.0.1/tcp/0"];
+    }
+}


### PR DESCRIPTION
Fixes #215.

## Summary

- expose a stable live read-only session view through `ILocalPeer`
- synchronize `Count` and point-in-time enumeration with session lifecycle changes
- document the session-view semantics and cover mutation, concurrency, and lifecycle behavior

## Validation

- built all 45 non-MAUI Release/CI projects successfully
- passed Libp2p.Core.Tests: 42/42
- passed Libp2p.E2eTests: 6/6
- passed independent concurrent-access and two-sided lifecycle probes

## CI status

The Test workflow currently stops during restore on the unchanged `main` dependency baseline because `SIPSorcery 10.0.3` raises two security advisories under warnings-as-errors. #208 contains the dependency/API update and has green Format and Test checks. After #208 lands, this branch can be rebased onto `main` and its checks rerun without duplicating that unrelated change here.